### PR TITLE
add SjpegFreeBuffer(…) to the library API so that it could be used not only in C++

### DIFF
--- a/src/enc.cc
+++ b/src/enc.cc
@@ -2178,6 +2178,12 @@ size_t SjpegEncode(const uint8_t* rgb, int W, int H, int stride,
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void SjpegFreeBuffer(uint8_t* buffer) {
+  delete[] buffer;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 size_t SjpegCompress(const uint8_t* rgb, int W, int H, int quality,
                      uint8_t** out_data) {
   return SjpegEncode(rgb, W, H, 3 * W, out_data, quality, 4, 0);

--- a/src/sjpeg.h
+++ b/src/sjpeg.h
@@ -31,6 +31,10 @@ extern "C" {
 // Returns the library's version.
 uint32_t SjpegVersion();
 
+// Can be used for freeing buffers obtained from 'SjpegEncode' and
+// 'SjpegCompress', if the library is used in a language different from C++.
+void SjpegFreeBuffer(uint8_t* buffer);
+
 // Main function
 // This is the simplest possible call. There is only one parameter (quality)
 // and most decisions will be made automatically (YUV420/YUV444/etc...).


### PR DESCRIPTION
Languages other than C++ do not have `delete[]` equivalent.
I think it would be a lot easier to use the library correctly with this patch.