### PR TITLE
add SjpegFreeBuffer() C-call to release buffer.

### DIFF
--- a/README
+++ b/README
@@ -37,15 +37,17 @@ size_t SjpegEncode(const uint8_t* const data,
 
 as well as functions with a C++ string-based API.
 
+The library comes primarily with a plain-C API, but a C++ version is available
+too, that uses std::string as interface.
+
+SjpegFreeBuffer() can be called release the buffers returned by SjpegEncode()
+and SjpegCompress().
+
 Also included in the library: some helper functions to inspect JPEG bitstream.
 They are meant to help re-processing a JPEG source:
   SjpegDimensions(): quickly get the JPEG picture dimensions.
   SjpegFindQuantizer(): return the quantization matrices
   SjpegEstimateQuality(): return an estimate of the encoding quality
-
-The library comes primarily with a plain-C API, but a C++ version is available
-too, that uses std::string as interface.
-
 
 * SjpegEncodeParam interface:
 *****************************

--- a/README.md
+++ b/README.md
@@ -40,15 +40,17 @@ size_t SjpegEncode(const uint8_t* const data,
 
 as well as functions with a C++ string-based API.
 
+The library comes primarily with a plain-C API, but a C++ version is available
+too, that uses `std::string` as interface.
+
+`SjpegFreeBuffer()` can be called release the buffers returned by `SjpegEncode()`
+and `SjpegCompress()`.
+
 Also included in the library: some helper functions to inspect JPEG bitstream.
 They are meant to help re-processing a JPEG source:
   `SjpegDimensions()`: quickly get the JPEG picture dimensions.
   `SjpegFindQuantizer()`: return the quantization matrices
   `SjpegEstimateQuality()`: return an estimate of the encoding quality
-
-The library comes primarily with a plain-C API, but a C++ version is available
-too, that uses `std::string` as interface.
-
 
 ## SjpegEncodeParam interface:
 

--- a/src/enc.cc
+++ b/src/enc.cc
@@ -2183,6 +2183,10 @@ size_t SjpegCompress(const uint8_t* rgb, int W, int H, int quality,
   return SjpegEncode(rgb, W, H, 3 * W, out_data, quality, 4, 0);
 }
 
+void SjpegFreeBuffer(const uint8_t* buffer) {
+  delete[] buffer;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 uint32_t SjpegVersion() {
@@ -2285,7 +2289,7 @@ std::string SjpegEncode(const uint8_t* rgb, int W, int H, int stride,
 
   std::string output;
   output.append(reinterpret_cast<const char*>(buf), size);
-  delete[] buf;
+  SjpegFreeBuffer(buf);
   return output;
 }
 
@@ -2297,7 +2301,7 @@ std::string SjpegCompress(const uint8_t* rgb, int W, int H, int quality) {
   uint8_t* data = NULL;
   size_t size = SjpegCompress(rgb, W, H, quality, &data);
   if (size > 0) output.append(reinterpret_cast<const char*>(data), size);
-  delete[] data;
+  SjpegFreeBuffer(data);
   return output;
 }
 

--- a/src/sjpeg.h
+++ b/src/sjpeg.h
@@ -36,7 +36,7 @@ uint32_t SjpegVersion();
 // and most decisions will be made automatically (YUV420/YUV444/etc...).
 // Returns the compressed size, and fills *out_data with the bitstream.
 // This returned buffer is allocated with 'new[]' operator. It must be
-// deallocated using 'delete[]' call.
+// deallocated by using 'delete[]' or SjpegFreeBuffer() calls.
 // Input data 'rgb' are the samples in sRGB format, in R/G/B memory order.
 // Picture dimension is width x height.
 // Retuns 0 in case of error.
@@ -50,7 +50,8 @@ size_t SjpegCompress(const uint8_t* rgb, int width, int height, int quality,
 //  positive.
 //
 // The compressed bytes are made available in *out_data, which is a buffer
-// allocated with new []. This buffer must be disallocated using 'delete []'.
+// allocated with new []. This buffer must be disallocated using 'delete []',
+// or by calling SjpegBufferFree().
 //
 // Return parameter -if positive- is the size of the JPEG string,
 // or 0 if an error occured.
@@ -95,6 +96,11 @@ size_t SjpegEncode(const uint8_t* rgb,
                    int quality,
                    int compression_method,
                    int yuv_mode);
+
+// Deallocate a compressed bitstream by calling 'delete []'. These are the
+// bitstreams returned by SjpegEncode() or SjpegCompress(). Useful if the
+// library has non-C++ bidings.
+void SjpegFreeBuffer(const uint8_t* buffer);
 
 ////////////////////////////////////////////////////////////////////////////////
 // JPEG-parsing tools


### PR DESCRIPTION
This is convenient for C-biding of the C++ API, wrapping the delete[].

Good suggestion by github/magicgoose.