### PR TITLE
-alt option: specifies an alternate picture to display

### DIFF
--- a/man/vjpeg.1
+++ b/man/vjpeg.1
@@ -41,6 +41,8 @@ The available key shortcuts are:
 .IP
    left/right ........ change the compression factor by +/- 10 units
 .IP
+   return ............ show alternate picture (if specified)
+.IP
    0/1/2/3 ........... change the yuv_mode to auto/yuv420/sharp-yuv420/yuv444
 .IP
    'o' ............... toggle Huffman optimization


### PR DESCRIPTION
use the 'return' key (\n) to show the alternate picture.
Has to have the same dimension than the source.