### PR TITLE
small speed-optim during PSNR search

### DIFF
--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -251,6 +251,9 @@ struct Encoder {
 
   void SinglePassScan();           // finalizing scan
   void SinglePassScanOptimized();  // optimize the Huffman table + finalize scan
+
+  // quantize and compute run/levels from already stored coeffs
+  void StoreRunLevels(DCTCoeffs* coeffs);
   // just write already stored run_levels & coeffs:
   void FinalPassScan(size_t nb_mbs, const DCTCoeffs* coeffs);
 


### PR DESCRIPTION
we don't need to optimize the Huffman table inside the loop, if
we're only targetting PSNR. We can do this after the search only.

+ preparing for a speed-up in ComputePSNR()

Change-Id: I2f2159c1997997aa4be131becbb9dcd9332e80e2