### PR TITLE
extract the dichotomy search as plugin

### DIFF
--- a/examples/sjpeg.cc
+++ b/examples/sjpeg.cc
@@ -84,19 +84,21 @@ int main(int argc, char * argv[]) {
     "  -short .......... Print shorter 1-line info.\n"
     "\n"
     "Advanced options:\n"
-    "  -yuv_mode ....... YUV mode to use:\n"
-    "                    0: automatic decision (default)\n"
-    "                    1: use YUV 4:2:0\n"
-    "                    2: use 'Sharp' YUV 4:2:0 conversion\n"
-    "                    3: use YUV 4:4:4 (full resolution for U/V planes)\n"
-    "  -no_limit ....... If true, allow the quality factor to be larger\n"
-    "                    than the original (JPEG input only).\n"
-    "  -no_optim ....... Don't use Huffman optimization (=faster)\n"
-    "  -no_adapt ....... Don't use adaptive quantization (=faster)\n"
-    "  -trellis ........ use trellis-based quantization (=slower)\n"
-    "  -no_metadata .... Ignore metadata from the source.\n"
-    "  -pass <int> ..... number of passes for -size or -psnr (default: 10\n"
-    "  -min_psnr <float> minimum PSNR value limit during dichotomy\n"
+    "  -yuv_mode .......... YUV mode to use:\n"
+    "                       0: automatic decision (default)\n"
+    "                       1: use YUV 4:2:0\n"
+    "                       2: use 'Sharp' YUV 4:2:0 conversion\n"
+    "                       3: use YUV 4:4:4 (full resolution for U/V planes)\n"
+    "  -no_limit .......... If true, allow the quality factor to be larger\n"
+    "                       than the original (JPEG input only).\n"
+    "  -no_optim .......... Don't use Huffman optimization (=faster)\n"
+    "  -no_adapt .......... Don't use adaptive quantization (=faster)\n"
+    "  -trellis ........... use trellis-based quantization (=slower)\n"
+    "  -no_metadata ....... Ignore metadata from the source.\n"
+    "  -pass <int> ........ number of passes for -size or -psnr (default: 10\n"
+    "  -qmin <int> ........ minimum acceptable quality factor during search\n"
+    "  -qmax <int> ........ maximum acceptable quality factor during search\n"
+    "  -tolerance <float> . tolerance for convergence during search\n"
     "\n"
     "\n"
     "If the input format is JPEG, the recompression will not go beyond the\n"
@@ -146,8 +148,12 @@ int main(int argc, char * argv[]) {
     } else if (!strcmp(argv[c], "-psnr") && c + 1 < argc) {
       param.target_mode = SjpegEncodeParam::TARGET_PSNR;
       param.target_value = atof(argv[++c]);
-    } else if (!strcmp(argv[c], "-min_psnr")) {
-      param.min_psnr = atof(argv[++c]);
+    } else if (!strcmp(argv[c], "-tolerance")) {
+      param.tolerance = atof(argv[++c]);
+    } else if (!strcmp(argv[c], "-qmin")) {
+      param.qmin = atof(argv[++c]);
+    } else if (!strcmp(argv[c], "-qmax")) {
+      param.qmax = atof(argv[++c]);
     } else if (!strcmp(argv[c], "-size") && c + 1 < argc) {
       param.target_mode = SjpegEncodeParam::TARGET_SIZE;
       param.target_value = atof(argv[++c]);

--- a/man/sjpeg.1
+++ b/man/sjpeg.1
@@ -46,7 +46,7 @@ option.
 .BI \-size " int
 Specify a target size to try and reach using several passes. By default, the
 internal search loop will try to get as close as possible to the specified
-size.
+size. This option has precedence over the \-pnsr one.
 See also the \-pass option.
 .TP
 .BI \-psnr " float
@@ -56,10 +56,19 @@ distortion. Note that the Peak-Signal-to-Noise is computed using the YUV
 samples, not the RGB ones.
 See also the \-pass option.
 .TP
-.BI \-min_psnr " float
-Minimum acceptable PSNR value for dichotomy (when \-psnr or \-size option
-is used). If possible, the search will try and avoid having a PSNR value
-lower than this threshold.
+.BI \-tolerance " float
+Tolerance (in percent) used during convergence to target value when \-psnr
+or \-size option is used.
+.TP
+.BI \-qmin " int
+Minimum acceptable quality factor used during the search (when \-psnr
+or \-size option is used). The search will halt if the quality adjustment
+would drop lower than the \fBqmin\fP value.
+.TP
+.BI \-qmax " int
+Maximum acceptable quality factor used during the search (when \-psnr
+or \-size option is used). The search will avoid using a quality factor
+larger than the \fBqmax\fP value.
 .TP
 .BI \-pass " int
 Specify the number of internal loop to use for convergence toward a target

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -355,13 +355,6 @@ struct Encoder {
   void AllocateBlocks(size_t num_blocks);
   void DesallocateBlocks();
 
-  // multi-pass parameters
-  SjpegEncodeParam::TargetMode target_mode_;
-  float target_value_;
-  int passes_;
-  float min_psnr_;
-  friend struct PassStats;
-
   // these are for regular compression methods 0 or 2.
   RunLevel base_run_levels_[64];
 
@@ -403,6 +396,11 @@ struct Encoder {
   void AnalyseHisto();
   void ResetHisto();  // initialize histos_[]
   Histo histos_[2];
+
+  // multi-pass parameters
+  int passes_;
+  SearchHook default_hook;
+  SearchHook* search_hook_;
 
   static const float kHistoWeight[QSIZE];
 


### PR DESCRIPTION
The interface object is 'SearchHook', with a default implementation.

It can be customize separately, and attached to the SjpegEncodeParam
to provide an alternate implementation.

new parameters: -qmin/-qmax/-tolerance
'min_psnr' parameter is removed.