### PR TITLE
Add possibility for using special dichotomy hook

### DIFF
--- a/examples/sjpeg.cc
+++ b/examples/sjpeg.cc
@@ -106,6 +106,11 @@ int main(int argc, char * argv[]) {
     "\n"
   ;
 
+#if defined(ALT_HOOK_CLASS)
+  ALT_HOOK_CLASS hook;
+  param.search_hook = &hook;
+#endif
+
   // parse command line
   if (argc <= 1) {
     fprintf(stderr, usage);


### PR DESCRIPTION
If ALT_HOOK_CLASS is defined, the related class is plugged in
as a replacement for the default implementation.

Change-Id: I451ba87f7707aa78fda1ef3ca3fd43720f8d1ff0