### PR TITLE
make 'quality' parameter be a float value

### DIFF
--- a/README
+++ b/README
@@ -23,7 +23,7 @@ The main header is src/sjpeg.h.
 This is mainly just one function to call, defined in src/sjpeg.h
 
 size_t SjpegCompress(const uint8_t* rgb, int width, int height,
-                     int quality, uint8_t** out_data);
+                     float quality, uint8_t** out_data);
 
 This function will make a lot of automatic decisions based on input samples.
 
@@ -32,8 +32,8 @@ There is a more fine-tuned variant available too:
 size_t SjpegEncode(const uint8_t* const data,
                    int W, int H, int stride,
                    uint8_t** const out_data,
-                   int quality, int compression_method,
-                   int yuv_mode);
+                   float quality, int compression_method,
+                   SjpegYUVMode yuv_mode);
 
 as well as functions with a C++ string-based API.
 

--- a/man/sjpeg.1
+++ b/man/sjpeg.1
@@ -25,7 +25,7 @@ A summary of all the possible options.
 .B \-version
 Print the version number (as major.minor.revision) and exit.
 .TP
-.BI \-q " int
+.BI \-q " float
 Specify the compression factor between 0 and 100. The default
 is 75.
 A small factor produces a smaller file
@@ -35,7 +35,7 @@ to never exceed the source's quality unless the -no_limit option is used.
 This option is disabled by subsequent use (in parsing order) of the \-r
 option.
 .TP
-.BI \-r " int
+.BI \-r " float
 Specify the reduction factor for JPEG source. The default is 100 (no reduction).
 A small reduction factor produces a smaller file with lower quality.
 When using a value of 100, the source JPEG file is only recompressed with

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -116,7 +116,8 @@ void ApplySharpYUVConversion(const uint8_t* const rgb,
 
 extern float GetQFactor(float q);   // convert quality factor -> scale factor
 extern void CopyQuantMatrix(const uint8_t in[64], uint8_t out[64]);
-extern void SetQuantMatrix(const uint8_t in[64], int q_factor, uint8_t out[64]);
+extern void SetQuantMatrix(const uint8_t in[64], float q_factor,
+                           uint8_t out[64]);
 extern void SetMinQuantMatrix(const uint8_t* const m, uint8_t out[64],
                               int tolerance);
 
@@ -195,7 +196,7 @@ struct Encoder {
   virtual ~Encoder();
 
   // setters
-  void SetQuality(int q);
+  void SetQuality(float q);
   void SetQuantMatrices(const uint8_t m[2][64]);
   void SetMinQuantMatrices(const uint8_t* const m[2], int tolerance);
   void SetCompressionMethod(int method);

--- a/tests/test_png_jpg.sh
+++ b/tests/test_png_jpg.sh
@@ -15,17 +15,17 @@ LIST="source1.png \
 
 set -e
 for f in ${LIST}; do
-  ${SJPEG} testdata/${f} -o ${TMP_JPEG2} -info
+  ${SJPEG} testdata/${f} -o ${TMP_JPEG2} -info -q 56.7
 done
 
 for f in ${LIST}; do
   ${SJPEG} testdata/${f} -o ${TMP_JPEG1} -quiet
-  ${SJPEG} ${TMP_JPEG1} -o ${TMP_JPEG2} -r 90 -short -info
+  ${SJPEG} ${TMP_JPEG1} -o ${TMP_JPEG2} -r 88.7 -short -info
 done
 
 for f in ${LIST}; do
-  ${SJPEG} testdata/${f} -o ${TMP_JPEG1} -quiet -no_metadata -q 30
-  ${SJPEG} ${TMP_JPEG1} -r 90 -o ${TMP_JPEG2} -short -info
+  ${SJPEG} testdata/${f} -o ${TMP_JPEG1} -quiet -no_metadata -q 30.3
+  ${SJPEG} ${TMP_JPEG1} -r 76.6542 -o ${TMP_JPEG2} -short -info
 done
 
 echo "OK!"


### PR DESCRIPTION
There's no particular reason to make it just an int.
+ Fix SjpegEstimateQuality (there was a missing kZigzag[])
Output is unchanged (for int values of quality)
Also: make 'reduction' parameter be a float too.

Change-Id: I86831552e57536ed193e11ce6ca123f8909b44f3