### PR TITLE
make GetPSNR() be the same on ARM and x86

### DIFF
--- a/src/dichotomy.cc
+++ b/src/dichotomy.cc
@@ -261,8 +261,11 @@ float Encoder::ComputeSize(const DCTCoeffs* coeffs) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static double GetPSNR(uint64_t err, uint64_t size) {
-  return (err > 0 && size > 0) ? 10. * log10(255. * 255. * size / err) : 99.;
+static float GetPSNR(uint64_t err, uint64_t size) {
+  // This expression is written such that it gives the same result on ARM
+  // and x86 (for large values of err/size in particular). Don't change it!
+  return (err > 0 && size > 0) ? -4.3429448f * log(size / (err / 255. / 255.))
+                               : 99.f;
 }
 
 float Encoder::ComputePSNR() const {


### PR DESCRIPTION
log() of large values seems to behave differently on ARM and x86
(at least arm64-v8a).

Change-Id: I3c528a702daa4807ccbef78beef97b5e81f2bdaa