### PR TITLE
fix the zigzag rationale

### DIFF
--- a/src/jpeg_tools.cc
+++ b/src/jpeg_tools.cc
@@ -108,7 +108,7 @@ int SjpegFindQuantizer(const uint8_t* src, size_t size,
                       | src[i + 1 + 2 * j + 1];
               v = (v > 255) ? 255 : v;
             }
-            quant[Tq][j] = (v < 1) ? 1u : (uint8_t)v;
+            quant[Tq][sjpeg::kZigzag[j]] = (v < 1) ? 1u : (uint8_t)v;
           }
         } else {
           // we don't store the pointer, but we record the component
@@ -146,7 +146,7 @@ float SjpegEstimateQuality(const uint8_t matrix[64], bool for_chroma) {
     SjpegQuantMatrix(quality, for_chroma, m);
     float score = 0;
     for (size_t i = 0; i < 64; ++i) {
-      const float diff = m[sjpeg::kZigzag[i]] - matrix[i];
+      const float diff = m[i] - matrix[i];
       score += diff * diff;
       if (score > best_score) {
         break;

--- a/src/sjpeg.h
+++ b/src/sjpeg.h
@@ -121,6 +121,7 @@ bool SjpegDimensions(const uint8_t* data, size_t size,
 
 // Finds the location of the first two quantization matrices within a JPEG
 // 'data' bitstream. Matrices are 64 coefficients stored as uint8_t.
+// The matrices are returned in natural order (not zigzag order).
 // Note that the input can be truncated to include the headers only, but still
 // must start as a valid JPEG with an 0xffd8 marker.
 // Returns the number of matrices detected.
@@ -130,9 +131,9 @@ int SjpegFindQuantizer(const uint8_t* data, size_t size,
 
 // Returns an estimation of the quality factor that would best approximate
 // the quantization coefficients in matrix[].
-// Note that matrix[] must be in zigzag order (the order used in the byte
-// stream). With this restriction, one can then pass the result of
-// SjpegFindQuantizer() directly to SjpegEstimateQuality().
+// Note that matrix[] must be in natural order (not the zigzag order used
+// in the byte stream). With this restriction, one can then pass the result
+// of SjpegFindQuantizer() directly to SjpegEstimateQuality().
 float SjpegEstimateQuality(const uint8_t matrix[64], bool for_chroma);
 
 // Generate a default quantization matrix for the given quality factor,

--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -41,5 +41,17 @@ ${SJPEG} ${SRC_FILE1} -o ${BAD_FILE} -quiet
 ${SJPEG} ${SRC_FILE2} -o
 ${SJPEG} -o ${BAD_FILE} -quiet
 
+# this test does not work for very low quality values (q<4)
+for q in `seq 4 100`; do
+  ${SJPEG} -q $q ${SRC_FILE1} -o ${TMP_FILE1} -no_adapt -no_optim &> /dev/null
+  # parse the 'estimated quality' result string, and compare to expected quality
+  a=(`${SJPEG} -i ${TMP_FILE1} | grep estimated | grep -Eo '[+-]?[0-9]+(\.0)'`)
+  q1="${a[0]}"
+  q2="${a[1]}"
+  q3="${q}.0"
+  if [ "x${q1}" != "x${q3}" ]; then echo "Y-Quality mismatch!"; exit 1; fi
+  if [ "x${q2}" != "x${q3}" ]; then echo "UV-Quality mismatch!"; exit 1; fi
+done
+
 echo "OK!"
 exit 0


### PR DESCRIPTION
SjpegEstimateQuality() need not take zigzag-ordered input any more.
+add test.