### PR TITLE
add SjpegEncodeParam::SetMinQuantization()

### DIFF
--- a/examples/sjpeg.cc
+++ b/examples/sjpeg.cc
@@ -228,12 +228,15 @@ int main(int argc, char * argv[]) {
     use_reduction = false;
   }
   if (use_reduction) {   // use 'reduction' factor for JPEG source
-    param.SetQuantMatrix(quant_matrices[0], 0, reduction);
-    param.SetQuantMatrix(quant_matrices[1], 1, reduction);
+    param.SetQuantization(quant_matrices, reduction);
     param.SetLimitQuantization(true);
   } else {    // the '-q' option has been used.
     param.SetQuality(quality);
-    param.SetLimitQuantization(false);
+    if (is_jpeg) {
+      param.SetMinQuantization(quant_matrices);
+    } else {
+      param.SetLimitQuantization(false);
+    }
   }
 
   if (estimate) {

--- a/src/dichotomy.cc
+++ b/src/dichotomy.cc
@@ -44,7 +44,7 @@ bool SearchHook::Setup(const SjpegEncodeParam& param) {
   qmin = (param.qmin < 0) ? 0 : param.qmin;
   qmax = (param.qmax > 100) ? 100 :
          (param.qmax < param.qmin) ? param.qmin : param.qmax;
-  q = Clamp(SjpegEstimateQuality(param.quant_[0], false), qmin, qmax);
+  q = Clamp(SjpegEstimateQuality(param.GetQuantMatrix(0), false), qmin, qmax);
   value = 0;   // undefined for at this point
   return true;
 }

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -190,14 +190,7 @@ struct Encoder {
 
   // setters
   void SetQuality(float q);
-  void SetQuantMatrices(const uint8_t m[2][64]);
-  void SetMinQuantMatrices(const uint8_t* const m[2], int tolerance);
   void SetCompressionMethod(int method);
-  void SetQuantizationBias(int bias, bool use_adaptive);
-  void SetQuantizationDeltas(int qdelta_luma, int qdelta_chroma);
-
-  typedef enum { ICC, EXIF, XMP, MARKERS } MetadataType;
-  void SetMetadata(const std::string& data, MetadataType type);
 
   // all-in-one init from SjpegEncodeParam.
   bool InitFromParam(const SjpegEncodeParam& param);
@@ -216,6 +209,18 @@ struct Encoder {
   // clipped is true if the MCU is clipped and needs replication
   virtual void GetSamples(int mb_x, int mb_y, bool clipped,
                           int16_t* out_blocks) = 0;
+
+ private:
+  // setters
+  void SetQuantMatrices(const uint8_t m[2][64]);
+  void SetMinQuantMatrices(const uint8_t m[2][64], int tolerance);
+  void SetDefaultMinQuantMatrices();
+
+  void SetQuantizationBias(int bias, bool use_adaptive);
+  void SetQuantizationDeltas(int qdelta_luma, int qdelta_chroma);
+
+  typedef enum { ICC, EXIF, XMP, MARKERS } MetadataType;
+  void SetMetadata(const std::string& data, MetadataType type);
 
  private:
   void CheckBuffers();


### PR DESCRIPTION
This is to directly set the quantization matrices, instead of taking the current
quant_[][] ones as min_quant_[].

+ add extra doc details
+ make some SjpegEncodeParam fields privates

Change-Id: I5701c0c7388c1484dd2d84b27d1bdcf2ec4f441d