### PR TITLE
fix bug in data_size calculation for EXIF chunk

### DIFF
--- a/src/headers.cc
+++ b/src/headers.cc
@@ -62,7 +62,7 @@ bool Encoder::WriteEXIF(const std::string& data) {
   const size_t kEXIF_len = 6;  // includes the \0's
   const size_t data_size = data.size() + kEXIF_len + 2;
   if (data_size > 0xffff) return false;
-  bw_.Reserve(data_size);
+  bw_.Reserve(data_size + 2);
   bw_.PutByte(0xff);
   bw_.PutByte(0xe1);
   bw_.PutByte((data_size >> 8) & 0xff);
@@ -118,7 +118,7 @@ bool Encoder::WriteXMP(const std::string& data) {
 }
 
 void Encoder::WriteDQT() {
-  const int data_size = 2 * 65 + 2;
+  const size_t data_size = 2 * 65 + 2;
   const uint8_t kDQTHeader[] = { 0xff, 0xdb, 0x00, (uint8_t)data_size };
   bw_.Reserve(data_size + 2);
   bw_.PutBytes(kDQTHeader, sizeof(kDQTHeader));
@@ -136,7 +136,7 @@ void Encoder::WriteDQT() {
 #define DATA_16b(X) ((uint8_t)((X) >> 8)), ((uint8_t)((X) & 0xff))
 
 void Encoder::WriteSOF() {   // SOF
-  const int data_size = 8 + 3 * nb_comps_;
+  const size_t data_size = 3 * nb_comps_ + 8;
   assert(data_size <= 255);
   const uint8_t kHeader[] = {
     0xff, 0xc0, DATA_16b(data_size),         // SOF0 marker, size
@@ -159,7 +159,7 @@ void Encoder::WriteDHT() {
   for (int c = 0; c < nb_tables; ++c) {   // luma, chroma
     for (int type = 0; type <= 1; ++type) {               // dc, ac
       const HuffmanTable* const h = Huffman_tables_[type * 2 + c];
-      const int data_size = 3 + 16 + h->nb_syms_;
+      const size_t data_size = 3 + 16 + h->nb_syms_;
       assert(data_size <= 255);
       bw_.Reserve(data_size + 2);
       bw_.PutByte(0xff);
@@ -176,7 +176,7 @@ void Encoder::WriteDHT() {
 ////////////////////////////////////////////////////////////////////////////////
 
 void Encoder::WriteSOS() {   // SOS
-  const int data_size = 6 + nb_comps_ * 2;
+  const size_t data_size = 3 + nb_comps_ * 2 + 3;
   assert(data_size <= 255);
   const uint8_t kHeader[] = {
       0xff, 0xda, DATA_16b(data_size), (uint8_t)nb_comps_


### PR DESCRIPTION
wouldn't normally show, since we always reserve() more than needed,
but better be exact!

+ clarify the size calc for SOF and SOS
+ use some 'size_t' instead of 'int'
