### PR TITLE
introduce generic ByteSink for outputting bytes

### DIFF
--- a/examples/sjpeg.cc
+++ b/examples/sjpeg.cc
@@ -300,10 +300,11 @@ int main(int argc, char * argv[]) {
   if (no_metadata) param.ResetMetadata();
 
   const double start = GetStopwatchTime();
-  const std::string out = SjpegEncode(&in_bytes[0], W, H, 3 * W, param);
+  std::string out;
+  const bool ok = SjpegEncode(&in_bytes[0], W, H, 3 * W, param, &out);
   const double encode_time = GetStopwatchTime() - start;
 
-  if (out.size() == 0) {
+  if (!ok) {
     fprintf(stderr, "ERROR: call to SjpegEncode() failed.\n");
     return -1;
   }

--- a/src/dichotomy.cc
+++ b/src/dichotomy.cc
@@ -113,7 +113,8 @@ void Encoder::LoopScan() {
   }
 
   const size_t nb_mbs = mb_w_ * mb_h_ * mcu_blocks_;
-  DCTCoeffs* const base_coeffs = new DCTCoeffs[nb_mbs];
+  DCTCoeffs* const base_coeffs = Alloc<DCTCoeffs>(nb_mbs);
+  if (base_coeffs == nullptr) return;
 
   uint8_t opt_quants[2][64];
 
@@ -183,7 +184,7 @@ void Encoder::LoopScan() {
   WriteSOS();
   FinalPassScan(nb_mbs, base_coeffs);
 
-  delete[] base_coeffs;
+  Free(base_coeffs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/sjpeg.h
+++ b/src/sjpeg.h
@@ -269,12 +269,27 @@ struct SearchHook {
   virtual ~SearchHook() {}
 };
 
+// Generic call taking a byte-sink
+//   Same as SjpegEncode(), except encoding parameters are passed in a
+//   SjpegEncodeParam. Upon failure (memory allocation or invalid parameter),
+//   the function returns false.
+namespace sjpeg { struct ByteSink; }
+bool SjpegEncode(const uint8_t* rgb, int width, int height, int stride,
+                 const SjpegEncodeParam& param, sjpeg::ByteSink* sink);
+
 // Same as the first version of SjpegEncode(), except encoding parameters are
 // delivered in a SjpegEncodeParam. Upon failure (memory allocation or
 // invalid parameter), the function returns an empty string.
+// TODO(skal): left for compatibility for now. Remove!
 std::string SjpegEncode(const uint8_t* rgb,
                         int width, int height, int stride,
                         const SjpegEncodeParam& param);
+
+// Same as the first version of SjpegEncode(), except encoding parameters are
+// passed in a SjpegEncodeParam. Upon failure (memory allocation or
+// invalid parameter), the function returns false.
+bool SjpegEncode(const uint8_t* rgb, int width, int height, int stride,
+                 const SjpegEncodeParam& param, std::string* output);
 
 // This version return data in *out_data. Returns 0 in case of error.
 size_t SjpegEncode(const uint8_t* rgb, int width, int height, int stride,
@@ -283,8 +298,8 @@ size_t SjpegEncode(const uint8_t* rgb, int width, int height, int stride,
 ////////////////////////////////////////////////////////////////////////////////
 // Variant of the function above, but using std::string as interface.
 
-std::string SjpegCompress(const uint8_t* rgb,
-                          int width, int height, float quality);
+bool SjpegCompress(const uint8_t* rgb,
+                   int width, int height, float quality, std::string* output);
 
 bool SjpegDimensions(const std::string& jpeg_data,
                      int* width, int* height, int* is_yuv420);


### PR DESCRIPTION
Implement some useful variants: MemorySink and StringSink (next: VectorSink)

+ Change the SjpegEncode() signature to take a string* instead of returning a string

Rationalize the Memory allocation: all internal buffers pass through
the Alloc() and Free() functions, so we can later track or limit allocation
traffic.

Protect all new[] with (std::nothrow) and catch the error.

+ polished the bit_writer.h/cc code.

TODO(after): move the ByteSink declaration to a public header (like: sjpeg.h) for exposure.

Change-Id: I6e1b3cee8f62af12e60a1e40b64e8e5e23102798