### PR TITLE
re-organize the interfaces with core-codec

### DIFF
--- a/src/bit_writer.cc
+++ b/src/bit_writer.cc
@@ -73,13 +73,16 @@ uint8_t* MemorySink::Commit(size_t used_size, size_t extra_size) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// StringSink
+// Sink factories
 
-uint8_t* StringSink::Commit(size_t used_size, size_t extra_size) {
-  pos_ += used_size;
-  assert(pos_ <= str_->size());
-  str_->resize(pos_ + extra_size);
-  return reinterpret_cast<uint8_t*>(&(*str_)[pos_]);
+std::shared_ptr<ByteSink> MakeByteSink(std::string* const output) {
+  return std::shared_ptr<ByteSink>(new (std::nothrow) StringSink(output));
+}
+
+// specialization for vector<uint8_t>
+template<>
+std::shared_ptr<ByteSink> MakeByteSink(std::vector<uint8_t>* const output) {
+  return std::shared_ptr<ByteSink>(new (std::nothrow) VectorSink(output));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -329,12 +329,13 @@ struct Encoder {
 
   // Memory management
   template<class T> T* Alloc(size_t num) {
-    T* const ptr = reinterpret_cast<T*>(MemoryAlloc(sizeof(T) * num));
+    assert(memory_hook_ != nullptr);
+    T* const ptr = reinterpret_cast<T*>(memory_hook_->Alloc(sizeof(T) * num));
     if (ptr == nullptr) SetError();
     return ptr;
   }
-  template<class T> static void Free(T* ptr) {
-    MemoryFree(reinterpret_cast<void*>(ptr));
+  template<class T> void Free(T* const ptr) {
+    memory_hook_->Free(reinterpret_cast<void*>(ptr));
   }
 
  private:
@@ -406,12 +407,11 @@ struct Encoder {
 
   // multi-pass parameters
   int passes_;
-  SearchHook default_hook;
+  SearchHook default_hook_;
   SearchHook* search_hook_;
 
   // lower memory management
-  static void* MemoryAlloc(size_t size);
-  static void MemoryFree(void* ptr);
+  MemoryManager* memory_hook_;
 
   static const float kHistoWeight[QSIZE];
 


### PR DESCRIPTION
 * add a MemoryManager interface for low-level malloc/free
 * add a MemoryManager hook to SjpegEncodeParam, in case some special
   allocator is needed (debugging, etc.)
 * Move ByteSink to sjpeg.h
 * abstract Sink<T> to take arbitrary container
 * specialize for string and vector<>
 * add some factories for string and vector<uint8_t> byte-sink, so the
   implementation details can stay in bit_writer.[c,hh]

Change-Id: I527ac1542f02caf6a688260af122b731f3be1cfb