### PR TITLE
sjpeg-sink: call Reset() for good in case of error

### DIFF
--- a/src/bit_writer.h
+++ b/src/bit_writer.h
@@ -85,6 +85,7 @@ class BitWriter {
   // Also flushes the previously written data.
   bool Reserve(size_t size) {
     const bool ok = sink_->Commit(byte_pos_, size, &buf_);
+    if (!ok) sink_->Reset();
     byte_pos_ = 0;
     return ok;
   }


### PR DESCRIPTION
(like the protocol said we should)

Change-Id: I7c4f8e59d2064c6980729f08c320a9fcf0a07df9