### PR TITLE
fix some errors in BlockRiskiness

### DIFF
--- a/examples/vjpeg.cc
+++ b/examples/vjpeg.cc
@@ -295,8 +295,11 @@ static void ComputeErrorMap() {
   }
 }
 
-extern double SjpegBlockRiskinessScore(const uint8_t* rgb, int stride,
-                                       int16_t score[8 * 8]);
+namespace sjpeg {
+extern double BlockRiskinessScore(const uint8_t* rgb, int stride,
+                                  int16_t score[8 * 8]);
+}
+
 static void ComputeRiskinessMap() {
   if (kParams.show != 5) {
     const size_t width = kParams.width;
@@ -307,14 +310,14 @@ static void ComputeRiskinessMap() {
     uint8_t* dst = &kParams.map[0];
     const uint8_t* src = &kParams.rgb[0];
     // We use 7x7 block iteration to avoid the oddity at right and bottom
-    // of the 8x8 block returned by SjpegBlockRiskinessScore().
+    // of the 8x8 block returned by BlockRiskinessScore().
     for (size_t j = 0; j + 7 <= height; j += 7) {
       for (size_t i = 0; i + 7 <= width; i += 7) {
         int16_t score_8x8[8 * 8];
-        SjpegBlockRiskinessScore(src + i * 3, stride, score_8x8);
+        sjpeg::BlockRiskinessScore(src + i * 3, stride, score_8x8);
         for (size_t k = 0, J = 0; J < 7; ++J) {
           for (size_t I = 0; I < 7; ++I, ++k) {
-            int score = score_8x8[k];
+            int score = score_8x8[I + J * 8];
             score *= 2;
             if (score > 255) score = 255;
             const size_t off = 3 * (i + I) + J * stride;

--- a/src/jpeg_tools.cc
+++ b/src/jpeg_tools.cc
@@ -16,8 +16,9 @@
 //
 // Author: Skal (pascal.massimino@gmail.com)
 
-#include <vector>
 #include <string.h>   // for memset
+#include <vector>
+
 #include "sjpegi.h"
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -211,10 +212,11 @@ SjpegYUVMode SjpegRiskiness(const uint8_t* rgb,
   return recommendation;
 }
 
+namespace sjpeg {
+
 // return riskiness score on an 8x8 block. Input is YUV444 block
 // of DCT coefficients (Y/U/V).
-double SjpegDCTRiskinessScore(const int16_t yuv[3 * 8],
-                              int16_t scores[8 * 8]) {
+double DCTRiskinessScore(const int16_t yuv[3 * 8], int16_t scores[8 * 8]) {
   uint16_t idx[64];
   for (int k = 0; k < 64; ++k) {
     const int v = (yuv[k + 0 * 64] + 128)
@@ -240,7 +242,7 @@ double SjpegDCTRiskinessScore(const int16_t yuv[3 * 8],
         total_score += score;
         count += 1.0;
       }
-      scores[I + J * 7] = static_cast<uint16_t>(score);
+      scores[I + J * 8] = static_cast<int16_t>(score);
     }
   }
   if (count > 0) total_score /= count;
@@ -251,10 +253,12 @@ double SjpegDCTRiskinessScore(const int16_t yuv[3 * 8],
 // This function returns the raw per-pixel riskiness scores. The input rgb[]
 // samples is a 8x8 block, the output is a 8x8 block.
 // Not an official API, because a little too specific. But still accessible.
-double SjpegBlockRiskinessScore(const uint8_t* rgb, int stride,
-                                int16_t scores[8 * 8]) {
-  sjpeg::RGBToYUVBlockFunc get_block = sjpeg::GetBlockFunc(true);
+double BlockRiskinessScore(const uint8_t* rgb, int stride,
+                           int16_t scores[8 * 8]) {
+  RGBToYUVBlockFunc get_block = GetBlockFunc(true);
   int16_t yuv444[3 * 64];
   get_block(rgb, stride, yuv444);
-  return SjpegDCTRiskinessScore(yuv444, scores);
+  return DCTRiskinessScore(yuv444, scores);
 }
+
+}   // namespace sjpeg

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -78,10 +78,10 @@ extern const int kRGBSize;
 extern const uint8_t kSharpnessScore[];
 
 // internal riskiness scoring functions:
-extern double SjpegDCTRiskinessScore(const int16_t yuv[3 * 8],
-                                     int16_t scores[8 * 8]);
-extern double SjpegBlockRiskinessScore(const uint8_t* rgb, int stride,
-                                       int16_t scores[8 * 8]);
+extern double DCTRiskinessScore(const int16_t yuv[3 * 8],
+                                int16_t scores[8 * 8]);
+extern double BlockRiskinessScore(const uint8_t* rgb, int stride,
+                                  int16_t scores[8 * 8]);
 
 ///////////////////////////////////////////////////////////////////////////////
 // RGB->YUV conversion


### PR DESCRIPTION
+ move these undocumented functions to sjpeg namespace
+ rationalize the score_8x8 use (it's not 7x7!)

Change-Id: I625e2fe4174bebd780d0df11a5f99d8a7b1dbd97