### PR TITLE
small API fix:

### DIFF
--- a/src/bit_writer.h
+++ b/src/bit_writer.h
@@ -64,7 +64,10 @@ template<class T> class Sink : public ByteSink {
     return true;
   }
   virtual bool Finalize() { ptr_->resize(pos_); return true; }
-  virtual void Reset() { ptr_->clear(); }
+  virtual void Reset() {
+    ptr_->clear();
+    pos_ = 0;
+  }
 
  protected:
   T* const ptr_;

--- a/src/enc.cc
+++ b/src/enc.cc
@@ -161,6 +161,7 @@ Encoder::Encoder(SjpegYUVMode yuv_mode, int W, int H, ByteSink* const sink)
   InitializeStaticPointers();
   memset(dc_codes_, 0, sizeof(dc_codes_));  // safety
   memset(ac_codes_, 0, sizeof(ac_codes_));
+  sink->Reset();
 }
 
 Encoder::~Encoder() {


### PR DESCRIPTION
+ the sink::Reset() was not resetting pos_
+ we were not calling sink->Reset() at the beginning of the Encode() call.
  This is convenient in the event one would want to re-use the same Sink object
  over multiple Encode() calls.

Change-Id: I983f0ac17bd50aabd6eb3a1e9de1aae65664b739