### PR TITLE
CI: Create AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+image: Visual Studio 2019
+configuration: Release
+
+environment:
+  matrix:
+  - arch: x64
+  - arch: ARM64
+
+before_build: cmake . -A %arch%
+
+build:
+  project: sjpeg.sln
+  verbosity: minimal
+
+artifacts:
+- path: /Release/*.exe


### PR DESCRIPTION
Creates an AppVeyor configuration to build sjpeg with CMake and Visual Studio 2019 (MSVC) for the x64 and ARM64 platforms.

An example build can be [found here](https://ci.appveyor.com/project/EwoutH/sjpeg/builds/38824899). AppVeyor needs to be enabled on the [GitHub Marketplace](https://github.com/marketplace/appveyor).

Currently the Arm64 job fails. See #109.

