### PR TITLE
Add basic CI configuration for Linux, macOS and Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Build
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-10
+      CXX: g++-10
+    steps:
+      - uses: actions/checkout@v2
+      - run: cmake .
+      - run: cmake --build .
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cmake .
+      - run: cmake --build .
+
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: mkdir build && cd build
+      - run: cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/android.cmake -DSJPEG_ANDROID_NDK_PATH=$ANDROID_NDK_LATEST_HOME
+        working-directory: build
+      - run: cmake --build .
+        working-directory: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,21 +8,21 @@ jobs:
       CC: gcc-10
       CXX: g++-10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: cmake .
       - run: cmake --build .
 
   macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: cmake .
       - run: cmake --build .
 
   android:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: mkdir build && cd build
       - run: cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/android.cmake -DSJPEG_ANDROID_NDK_PATH=$ANDROID_NDK_LATEST_HOME
         working-directory: build


### PR DESCRIPTION
Adds a basic CI configuration using GitHub Actions which builds sjpeg:
 - on Linux using CMake and GCC 10
 - on macOS using CMake and AppleClang 12
 - for Android using CMake and the Android NDK

This configuration uses GitHub Actions, which needs to be [activated here](https://github.com/webmproject/sjpeg/actions). An example build from my fork can be [seen here](https://github.com/EwoutH/sjpeg/actions/runs/775121110).

For Windows there is already an AppVeyor configuration, which was added in #110.