### PR TITLE
CMakeLists: fix sjpeg-utils dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ add_library(sjpeg-utils
             ${CMAKE_CURRENT_SOURCE_DIR}/examples/utils.cc
             ${CMAKE_CURRENT_SOURCE_DIR}/examples/utils.h
 )
+target_link_libraries(sjpeg-utils sjpeg)
 
 if(WIN32)
   # quiet warnings related to fopen, sscanf


### PR DESCRIPTION
This library relies on sjpeg::EncoderParam::ResetMetadata() when
SJPEG_HAVE_JPEG or SJPEG_HAVE_PNG are set. The header is included
unconditionally, so the dependency is treated the same.

Fixes undefined reference link errors to the function.

Thanks to @leleliu008 for the report and proposed fix.

Fixes #120.
