### PR TITLE
InitializeStaticPointers: make init thread safe

### DIFF
--- a/src/enc.cc
+++ b/src/enc.cc
@@ -20,6 +20,8 @@
 #include <math.h>
 #include <float.h>    // for FLT_MAX
 #include <stdint.h>
+
+#include <mutex>  // NOLINT
 #include <new>
 
 #define SJPEG_NEED_ASM_HEADERS
@@ -256,12 +258,13 @@ void (*Encoder::fDCT_)(int16_t* in, int num_blocks) = nullptr;
 Encoder::StoreHistoFunc Encoder::store_histo_ = nullptr;
 
 void Encoder::InitializeStaticPointers() {
-  if (fDCT_ == nullptr) {
+  static std::once_flag once;
+  std::call_once(once, []() {
     store_histo_ = GetStoreHistoFunc();
     quantize_block_ = GetQuantizeBlockFunc();
     quantize_error_ = GetQuantizeErrorFunc();
     fDCT_ = GetFdct();
-  }
+  });
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/enc.cc
+++ b/src/enc.cc
@@ -16,6 +16,7 @@
 //
 // Author: Skal (pascal.massimino@gmail.com)
 
+#include <assert.h>
 #include <stdlib.h>
 #include <math.h>
 #include <float.h>    // for FLT_MAX
@@ -265,6 +266,10 @@ void Encoder::InitializeStaticPointers() {
     quantize_error_ = GetQuantizeErrorFunc();
     fDCT_ = GetFdct();
   });
+  assert(store_histo_ != nullptr);
+  assert(quantize_block_ != nullptr);
+  assert(quantize_error_ != nullptr);
+  assert(fDCT_ != nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
fixes TSan warnings:
Read of size 8 at 0x7f6c00f850e8 by thread T914:
    #0 InitializeStaticPointers
    #1 sjpeg::Encoder::Encoder(SjpegYUVMode, int, int, sjpeg::ByteSink*)
...
  Previous write of size 8 at 0x7f6c00f850e8 by thread T875:
    #0 InitializeStaticPointers
    #1 sjpeg::Encoder::Encoder(SjpegYUVMode, int, int, sjpeg::ByteSink*)