### PR TITLE
EncoderNV12: remove unused W_/H_ private members

### DIFF
--- a/src/enc.cc
+++ b/src/enc.cc
@@ -1930,7 +1930,6 @@ class EncoderNV12 : public Encoder {
   }
 
  private:
-  int W_, H_;
   const uint8_t* y_;
   int y_step_;
   const uint8_t* uv_;


### PR DESCRIPTION
This matches the other classes that derive from Encoder.