### PR TITLE
add missing <cstdlib> include

### DIFF
--- a/src/enc.cc
+++ b/src/enc.cc
@@ -22,6 +22,7 @@
 #include <float.h>    // for FLT_MAX
 #include <stdint.h>
 
+#include <cstdlib>
 #include <mutex>  // NOLINT
 #include <new>
 

--- a/src/jpeg_tools.cc
+++ b/src/jpeg_tools.cc
@@ -17,6 +17,8 @@
 // Author: Skal (pascal.massimino@gmail.com)
 
 #include <string.h>   // for memset
+
+#include <cstdlib>
 #include <vector>
 
 #include "sjpegi.h"


### PR DESCRIPTION
needed for uses of `std::abs`

PiperOrigin-RevId: 693699945
