### PR TITLE
CMakeLists.txt: bump minimum cmake version to 3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: cmake . -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - run: cmake .
       - run: cmake --build .
 
   macos:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5...3.10)
 
 # Prefer GLVND libraries by default.
 if(POLICY CMP0072)


### PR DESCRIPTION
Fixes an error with cmake 4.0.0:
  Compatibility with CMake < 3.5 has been removed from CMake.

Also indicate that the file has been updated to support 3.10 to avoid:
  Compatibility with CMake < 3.10 will be removed from a future version
  of CMake.

3.5 is relatively old, but maintain compatibility while cmake still
supports it.

Fixes: #131
