### PR TITLE
ci.yml: remove explicit CC/CXX definition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: cmake .
-      - run: cmake --build . -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - run: cmake . -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - run: cmake --build .
 
   macos:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on: [push, pull_request]
 jobs:
   linux:
     runs-on: ubuntu-latest
-    env:
-      CC: gcc-10
-      CXX: g++-10
     steps:
       - uses: actions/checkout@v3
       - run: cmake .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: cmake .
-      - run: cmake --build .
+      - run: cmake --build . -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
   macos:
     runs-on: macos-latest


### PR DESCRIPTION
Just pick up whatever version of gcc is installed. This fixes an issue
with ubuntu-latest where gcc-10/g++-10 are not installed.
