### PR TITLE
{vjpeg,yuv_convert}.cc: normalize void param lists

### DIFF
--- a/examples/vjpeg.cc
+++ b/examples/vjpeg.cc
@@ -572,8 +572,7 @@ static void HandleReshape(int width, int height) {
   kParams.viewport_height = height;
 }
 
-
-static void HandleDisplay(void) {
+static void HandleDisplay() {
   if (kParams.out_rgb.size() == 0) return;
   glPushMatrix();
   glPixelZoom((GLfloat)(+1. / kParams.width * kParams.viewport_width),
@@ -601,7 +600,7 @@ static void HandleDisplay(void) {
   glutSwapBuffers();
 }
 
-static void StartDisplay(void) {
+static void StartDisplay() {
   const int width = kParams.width;
   const int height = kParams.height;
   const int swidth = glutGet(GLUT_SCREEN_WIDTH);
@@ -627,7 +626,7 @@ static void StartDisplay(void) {
 //------------------------------------------------------------------------------
 // Main
 
-static void Help(void) {
+static void Help() {
   printf("Usage: vjpeg in_file [options]\n\n"
          "Visualizer for SJPEG (re-)compression, using OpenGL\n"
          "Options are:\n"

--- a/src/yuv_convert.cc
+++ b/src/yuv_convert.cc
@@ -110,7 +110,7 @@ static uint32_t kLinearToGammaTab[GAMMA_TABLE_SIZE + 2];
 #define GAMMA_TO_LINEAR_BITS 14
 static uint32_t kGammaToLinearTab[MAX_Y_T + 1];   // size scales with Y_FIX
 
-static void InitGammaTablesF(void) {
+static void InitGammaTablesF() {
   static bool done = false;
   assert(2 * GAMMA_TO_LINEAR_BITS < 32);  // we use uint32_t intermediate values
   if (!done) {


### PR DESCRIPTION
replace `(void)` with `()`; use of this synonym is more common in C++
code.
