### PR TITLE
sjpegi.h,Encoder: mark static const member as constexpr

### DIFF
--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -372,7 +372,7 @@ struct Encoder {
   int DCs_[3];           // DC predictors
 
   // DCT coefficients storage, aligned
-  static const size_t ALIGN_CST = 15;
+  static constexpr size_t ALIGN_CST = 15;
   uint8_t* in_blocks_base_;   // base memory for blocks
   int16_t* in_blocks_;        // aligned pointer to in_blocks_base_
   bool have_coeffs_;          // true if the Fourier coefficients are stored


### PR DESCRIPTION
This fixes the const declaration of `ALIGN_CST` which has an initial
value, but is not technically a definition. Instead constexpr (which
counts as a definition) is used. This fixes linker errors in some
situations.

PiperOrigin-RevId: 307131466
