### PR TITLE
md5sum.h: fix tautological comparison warning on 32-bit systems

### DIFF
--- a/src/md5sum.h
+++ b/src/md5sum.h
@@ -30,7 +30,7 @@ class MD5Digest {
   explicit MD5Digest(const std::string& data = "")
       : A(0x67452301), B(0xefcdab89), C(0x98badcfe), D(0x10325476) {
     uint32_t s = data.size();
-    assert(data.size() < (1ull << 32));
+    assert(static_cast<uint64_t>(data.size()) < (1ull << 32));
     uint32_t i, j;
     for (i = 0; i + 64 <= s; i += 64) Add((const uint8_t*)&data[i]);
     uint8_t block[64 + 64];


### PR DESCRIPTION
### Summary
On 32-bit architectures where `std::string::size_type` (`size_t`) is 32-bit, `data.size() < (1ull << 32)` is tautologically true and causes Clang/GCC to emit `-Wtautological-constant-out-of-range-compare` under `-Werror`.

Casting `data.size()` to `uint64_t` preserves the 4GB bounds assertion on 64-bit systems while silencing the compiler warning on 32-bit systems.