### PR TITLE
Add native BGRA and RGBA input paths (zero-copy, bit-exact)

### DIFF
--- a/src/colors_rgb.cc
+++ b/src/colors_rgb.cc
@@ -22,6 +22,7 @@
 
 #include <string.h>
 
+#include "sjpeg.h"
 #define SJPEG_NEED_ASM_HEADERS
 #include "sjpegi.h"
 
@@ -286,6 +287,151 @@ static void Get16x16Block_SSE2(const uint8_t* data, int step, int16_t* blocks) {
   Get16x8_SSE2(data + 8 * step, step, blocks + 2 * 64, blocks + 4 * 64 + 4 * 8);
 }
 
+// Convert 8 packed BGRA samples to r[], g[], b[] (alpha dropped, R/B swapped).
+// Produces exactly the same r/g/b registers as RGB24PackedToPlanar for the same
+// pixels, so all downstream YUV math is bit-identical.
+static inline void BGRA32PackedToPlanar(const uint8_t* const bgra,
+                                        __m128i* const r, __m128i* const g,
+                                        __m128i* const b) {
+  const __m128i zero = _mm_setzero_si128();
+  const __m128i in0 = LOAD_16(bgra + 0);   // B0 G0 R0 A0 ... B3 G3 R3 A3
+  const __m128i in1 = LOAD_16(bgra + 16);  // B4 G4 R4 A4 ... B7 G7 R7 A7
+  const __m128i t0 = _mm_unpacklo_epi8(in0, in1);
+  const __m128i t1 = _mm_unpackhi_epi8(in0, in1);
+  const __m128i t2 = _mm_unpacklo_epi8(t0, t1);
+  const __m128i t3 = _mm_unpackhi_epi8(t0, t1);
+  const __m128i t4 = _mm_unpacklo_epi8(t2, t3);  // B0..B7 | G0..G7
+  const __m128i t5 = _mm_unpackhi_epi8(t2, t3);  // R0..R7 | A0..A7
+  *b = _mm_unpacklo_epi8(t4, zero);
+  *g = _mm_unpackhi_epi8(t4, zero);
+  *r = _mm_unpacklo_epi8(t5, zero);
+}
+
+static void Get8x8Block_BGRA_SSE2(const uint8_t* data, int step, int16_t* out) {
+  for (int y = 8; y > 0; --y) {
+    __m128i r, g, b;
+    BGRA32PackedToPlanar(data, &r, &g, &b);
+    ToYUV_8(&r, &g, &b, out);
+    out += 8;
+    data += step;
+  }
+}
+
+static void Get8x8Block_Y_BGRA_SSE2(const uint8_t* data, int step,
+                                    int16_t* out) {
+  for (int y = 8; y > 0; --y) {
+    __m128i r, g, b;
+    BGRA32PackedToPlanar(data, &r, &g, &b);
+    ToY_8(&r, &g, &b, out);
+    out += 8;
+    data += step;
+  }
+}
+
+// 16 pixels wide = 64 bytes; RGB used offset 3*8(=24)=8 px, BGRA uses 4*8(=32).
+static void Get16x8_BGRA_SSE2(const uint8_t* src1, int src_stride,
+                              int16_t y[4 * 64], int16_t uv[2 * 64]) {
+  for (int i = 4; i > 0; --i, src1 += 2 * src_stride) {
+    __m128i r_acc1, r_acc2, g_acc1, g_acc2, b_acc1, b_acc2;
+    __m128i r, g, b;
+    const uint8_t* const src2 = src1 + src_stride;
+    BGRA32PackedToPlanar(src1 + 0, &r, &g, &b);
+    ToY_16x16(&r, &g, &b, y + 0 * 64 + 0, &r_acc1, &g_acc1, &b_acc1, false);
+    BGRA32PackedToPlanar(src1 + 4 * 8, &r, &g, &b);
+    ToY_16x16(&r, &g, &b, y + 1 * 64 + 0, &r_acc2, &g_acc2, &b_acc2, false);
+    BGRA32PackedToPlanar(src2 + 0, &r, &g, &b);
+    ToY_16x16(&r, &g, &b, y + 0 * 64 + 8, &r_acc1, &g_acc1, &b_acc1, true);
+    BGRA32PackedToPlanar(src2 + 4 * 8, &r, &g, &b);
+    ToY_16x16(&r, &g, &b, y + 1 * 64 + 8, &r_acc2, &g_acc2, &b_acc2, true);
+    Condense16To8(&r_acc1, &r_acc2);
+    Condense16To8(&g_acc1, &g_acc2);
+    Condense16To8(&b_acc1, &b_acc2);
+    ToUV_8x8(&r_acc2, &g_acc2, &b_acc2, uv);
+    y += 2 * 8;
+    uv += 8;
+  }
+}
+
+static void Get16x16Block_BGRA_SSE2(const uint8_t* data, int step,
+                                    int16_t* blocks) {
+  Get16x8_BGRA_SSE2(data + 0 * step, step, blocks + 0 * 64,
+                    blocks + 4 * 64 + 0 * 8);
+  Get16x8_BGRA_SSE2(data + 8 * step, step, blocks + 2 * 64,
+                    blocks + 4 * 64 + 4 * 8);
+}
+
+// Convert 8 packed RGBA samples to r[], g[], b[] (alpha dropped).
+// Produces exactly the same r/g/b registers as RGB24PackedToPlanar for the same
+// pixels, so all downstream YUV math is bit-identical.
+static inline void RGBA32PackedToPlanar(const uint8_t* const rgba,
+                                        __m128i* const r, __m128i* const g,
+                                        __m128i* const b) {
+  const __m128i zero = _mm_setzero_si128();
+  const __m128i in0 = LOAD_16(rgba + 0);   // R0 G0 B0 A0 ... R3 G3 B3 A3
+  const __m128i in1 = LOAD_16(rgba + 16);  // R4 G4 B4 A4 ... R7 G7 B7 A7
+  const __m128i t0 = _mm_unpacklo_epi8(in0, in1);
+  const __m128i t1 = _mm_unpackhi_epi8(in0, in1);
+  const __m128i t2 = _mm_unpacklo_epi8(t0, t1);
+  const __m128i t3 = _mm_unpackhi_epi8(t0, t1);
+  const __m128i t4 = _mm_unpacklo_epi8(t2, t3);  // R0..R7 | G0..G7
+  const __m128i t5 = _mm_unpackhi_epi8(t2, t3);  // B0..B7 | A0..A7
+  *r = _mm_unpacklo_epi8(t4, zero);
+  *g = _mm_unpackhi_epi8(t4, zero);
+  *b = _mm_unpacklo_epi8(t5, zero);
+}
+
+static void Get8x8Block_RGBA_SSE2(const uint8_t* data, int step, int16_t* out) {
+  for (int y = 8; y > 0; --y) {
+    __m128i r, g, b;
+    RGBA32PackedToPlanar(data, &r, &g, &b);
+    ToYUV_8(&r, &g, &b, out);
+    out += 8;
+    data += step;
+  }
+}
+
+static void Get8x8Block_Y_RGBA_SSE2(const uint8_t* data, int step,
+                                    int16_t* out) {
+  for (int y = 8; y > 0; --y) {
+    __m128i r, g, b;
+    RGBA32PackedToPlanar(data, &r, &g, &b);
+    ToY_8(&r, &g, &b, out);
+    out += 8;
+    data += step;
+  }
+}
+
+static void Get16x8_RGBA_SSE2(const uint8_t* src1, int src_stride,
+                              int16_t y[4 * 64], int16_t uv[2 * 64]) {
+  for (int i = 4; i > 0; --i, src1 += 2 * src_stride) {
+    __m128i r_acc1, r_acc2, g_acc1, g_acc2, b_acc1, b_acc2;
+    __m128i r, g, b;
+    const uint8_t* const src2 = src1 + src_stride;
+    RGBA32PackedToPlanar(src1 + 0, &r, &g, &b);
+    ToY_16x16(&r, &g, &b, y + 0 * 64 + 0, &r_acc1, &g_acc1, &b_acc1, false);
+    RGBA32PackedToPlanar(src1 + 4 * 8, &r, &g, &b);
+    ToY_16x16(&r, &g, &b, y + 1 * 64 + 0, &r_acc2, &g_acc2, &b_acc2, false);
+    RGBA32PackedToPlanar(src2 + 0, &r, &g, &b);
+    ToY_16x16(&r, &g, &b, y + 0 * 64 + 8, &r_acc1, &g_acc1, &b_acc1, true);
+    RGBA32PackedToPlanar(src2 + 4 * 8, &r, &g, &b);
+    ToY_16x16(&r, &g, &b, y + 1 * 64 + 8, &r_acc2, &g_acc2, &b_acc2, true);
+    Condense16To8(&r_acc1, &r_acc2);
+    Condense16To8(&g_acc1, &g_acc2);
+    Condense16To8(&b_acc1, &b_acc2);
+    ToUV_8x8(&r_acc2, &g_acc2, &b_acc2, uv);
+    y += 2 * 8;
+    uv += 8;
+  }
+}
+
+static void Get16x16Block_RGBA_SSE2(const uint8_t* data, int step,
+                                    int16_t* blocks) {
+  Get16x8_RGBA_SSE2(data + 0 * step, step, blocks + 0 * 64,
+                    blocks + 4 * 64 + 0 * 8);
+  Get16x8_RGBA_SSE2(data + 8 * step, step, blocks + 2 * 64,
+                    blocks + 4 * 64 + 4 * 8);
+}
+
 #undef LOAD_16
 #undef STORE_16
 
@@ -493,6 +639,139 @@ static void Get16x16Block_NEON(const uint8_t* data, int step, int16_t* yuv) {
   Get16x8_NEON(data + 8 * step, step, yuv + 2 * 64, uv + 4 * 8);
 }
 
+// 8 packed BGRA -> r/g/b (alpha dropped).
+// Produces the same r/g/b as RGB24PackedToPlanar, so YUV math is bit-identical.
+static void BGRA32PackedToPlanar(const uint8_t* const bgra, int16x8_t* const r,
+                                 int16x8_t* const g, int16x8_t* const b) {
+  const uint8x8x4_t in = vld4_u8(bgra);  // val[0]=B val[1]=G val[2]=R val[3]=A
+  *b = vreinterpretq_s16_u16(vmovl_u8(in.val[0]));
+  *g = vreinterpretq_s16_u16(vmovl_u8(in.val[1]));
+  *r = vreinterpretq_s16_u16(vmovl_u8(in.val[2]));
+}
+
+static void Get8x8Block_BGRA_NEON(const uint8_t* data, int step, int16_t* out) {
+  const int16x4_t kC1 = vld1_s16(kCoeff1);
+  const int16x4_t kC2 = vld1_s16(kCoeff2);
+  for (int y = 8; y > 0; --y) {
+    int16x8_t r, g, b;
+    BGRA32PackedToPlanar(data, &r, &g, &b);
+    ToYUV_8(r, g, b, kC1, kC2, out);
+    out += 8;
+    data += step;
+  }
+}
+
+static void Get8x8Block_Y_BGRA_NEON(const uint8_t* data, int step,
+                                    int16_t* out) {
+  const int16x4_t kC1 = vld1_s16(kCoeff1);
+  for (int y = 8; y > 0; --y) {
+    int16x8_t r, g, b;
+    BGRA32PackedToPlanar(data, &r, &g, &b);
+    ToY_8(r, g, b, kC1, out);
+    out += 8;
+    data += step;
+  }
+}
+
+// convert two 16x8 BGRA blocks into two blocks of luma, and 2 blocks of U/V
+static void Get16x8_BGRA_NEON(const uint8_t* src1, int src_stride,
+                              int16_t y[4 * 64], int16_t uv[2 * 64]) {
+  const int16x4_t kC1 = vld1_s16(kCoeff1);
+  const int16x4_t kC2 = vld1_s16(kCoeff2);
+  for (int i = 4; i > 0; --i, src1 += 2 * src_stride) {
+    int16x8_t r_acc1, r_acc2, g_acc1, g_acc2, b_acc1, b_acc2;
+    int16x8_t r, g, b;
+    const uint8_t* const src2 = src1 + src_stride;
+    BGRA32PackedToPlanar(src1 + 0 * 8, &r, &g, &b);
+    ToY_16x16(r, g, b, y + 0 * 64 + 0, &r_acc1, &g_acc1, &b_acc1, kC1, false);
+    BGRA32PackedToPlanar(src1 + 4 * 8, &r, &g, &b);
+    ToY_16x16(r, g, b, y + 1 * 64 + 0, &r_acc2, &g_acc2, &b_acc2, kC1, false);
+    BGRA32PackedToPlanar(src2 + 0 * 8, &r, &g, &b);
+    ToY_16x16(r, g, b, y + 0 * 64 + 8, &r_acc1, &g_acc1, &b_acc1, kC1, true);
+    BGRA32PackedToPlanar(src2 + 4 * 8, &r, &g, &b);
+    ToY_16x16(r, g, b, y + 1 * 64 + 8, &r_acc2, &g_acc2, &b_acc2, kC1, true);
+    Condense16To8(r_acc1, &r_acc2);
+    Condense16To8(g_acc1, &g_acc2);
+    Condense16To8(b_acc1, &b_acc2);
+    ToUV_8x8(r_acc2, g_acc2, b_acc2, kC2, uv);
+    y += 2 * 8;
+    uv += 8;
+  }
+}
+
+static void Get16x16Block_BGRA_NEON(const uint8_t* data, int step,
+                                    int16_t* yuv) {
+  int16_t* const uv = yuv + 4 * 64;
+  Get16x8_BGRA_NEON(data + 0 * step, step, yuv + 0 * 64, uv + 0 * 8);
+  Get16x8_BGRA_NEON(data + 8 * step, step, yuv + 2 * 64, uv + 4 * 8);
+}
+
+// 8 packed RGBA -> r/g/b (alpha dropped).
+// Produces the same r/g/b as RGB24PackedToPlanar, so YUV math is bit-identical.
+static void RGBA32PackedToPlanar(const uint8_t* const rgba, int16x8_t* const r,
+                                 int16x8_t* const g, int16x8_t* const b) {
+  const uint8x8x4_t in = vld4_u8(rgba);  // val[0]=R val[1]=G val[2]=B val[3]=A
+  *r = vreinterpretq_s16_u16(vmovl_u8(in.val[0]));
+  *g = vreinterpretq_s16_u16(vmovl_u8(in.val[1]));
+  *b = vreinterpretq_s16_u16(vmovl_u8(in.val[2]));
+}
+
+static void Get8x8Block_RGBA_NEON(const uint8_t* data, int step, int16_t* out) {
+  const int16x4_t kC1 = vld1_s16(kCoeff1);
+  const int16x4_t kC2 = vld1_s16(kCoeff2);
+  for (int y = 8; y > 0; --y) {
+    int16x8_t r, g, b;
+    RGBA32PackedToPlanar(data, &r, &g, &b);
+    ToYUV_8(r, g, b, kC1, kC2, out);
+    out += 8;
+    data += step;
+  }
+}
+
+static void Get8x8Block_Y_RGBA_NEON(const uint8_t* data, int step,
+                                    int16_t* out) {
+  const int16x4_t kC1 = vld1_s16(kCoeff1);
+  for (int y = 8; y > 0; --y) {
+    int16x8_t r, g, b;
+    RGBA32PackedToPlanar(data, &r, &g, &b);
+    ToY_8(r, g, b, kC1, out);
+    out += 8;
+    data += step;
+  }
+}
+
+static void Get16x8_RGBA_NEON(const uint8_t* src1, int src_stride,
+                              int16_t y[4 * 64], int16_t uv[2 * 64]) {
+  const int16x4_t kC1 = vld1_s16(kCoeff1);
+  const int16x4_t kC2 = vld1_s16(kCoeff2);
+  for (int i = 4; i > 0; --i, src1 += 2 * src_stride) {
+    int16x8_t r_acc1, r_acc2, g_acc1, g_acc2, b_acc1, b_acc2;
+    int16x8_t r, g, b;
+    const uint8_t* const src2 = src1 + src_stride;
+    RGBA32PackedToPlanar(src1 + 0 * 8, &r, &g, &b);
+    ToY_16x16(r, g, b, y + 0 * 64 + 0, &r_acc1, &g_acc1, &b_acc1, kC1, false);
+    RGBA32PackedToPlanar(src1 + 4 * 8, &r, &g, &b);
+    ToY_16x16(r, g, b, y + 1 * 64 + 0, &r_acc2, &g_acc2, &b_acc2, kC1, false);
+    RGBA32PackedToPlanar(src2 + 0 * 8, &r, &g, &b);
+    ToY_16x16(r, g, b, y + 0 * 64 + 8, &r_acc1, &g_acc1, &b_acc1, kC1, true);
+    RGBA32PackedToPlanar(src2 + 4 * 8, &r, &g, &b);
+    ToY_16x16(r, g, b, y + 1 * 64 + 8, &r_acc2, &g_acc2, &b_acc2, kC1, true);
+    Condense16To8(r_acc1, &r_acc2);
+    Condense16To8(g_acc1, &g_acc2);
+    Condense16To8(b_acc1, &b_acc2);
+    ToUV_8x8(r_acc2, g_acc2, b_acc2, kC2, uv);
+    y += 2 * 8;
+    uv += 8;
+  }
+}
+
+static void Get16x16Block_RGBA_NEON(const uint8_t* data, int step,
+                                    int16_t* yuv) {
+  int16_t* const uv = yuv + 4 * 64;
+  Get16x8_RGBA_NEON(data + 0 * step, step, yuv + 0 * 64, uv + 0 * 8);
+  Get16x8_RGBA_NEON(data + 8 * step, step, yuv + 2 * 64, uv + 4 * 8);
+}
+
 #undef MULT_S32_S16_LARGE
 #undef DOT_PROD_PREAMBLE
 #undef DOT_PROD1
@@ -600,9 +879,187 @@ static void Get16x16Block_C(const uint8_t* rgb, int step, int16_t* yuv) {
   Get16x8Block_C(rgb + 8 * step, step, yuv + 2 * 64, yuv + 4 * 64 + 4 * 8);
 }
 
+// Copy a BGRA pixel into an RGB triplet (alpha dropped, R/B swapped).
+static inline void BgraToRgb(const uint8_t* p, uint8_t rgb[3]) {
+  rgb[0] = p[2];
+  rgb[1] = p[1];
+  rgb[2] = p[0];
+}
+
+static void Get8x8Block_BGRA_C(const uint8_t* data, int step, int16_t* out) {
+  for (int y = 8; y > 0; --y) {
+    for (int x = 0; x < 8; ++x) {
+      uint8_t rgb[3];
+      BgraToRgb(data + 4 * x, rgb);
+      ToYUV(rgb, out + x);
+    }
+    out += 8;
+    data += step;
+  }
+}
+
+static void Get8x8Block_Y_BGRA_C(const uint8_t* data, int step, int16_t* out) {
+  for (int y = 8; y > 0; --y) {
+    for (int x = 0; x < 8; ++x) {
+      uint8_t rgb[3];
+      BgraToRgb(data + 4 * x, rgb);
+      out[x] = ToY(rgb);
+    }
+    out += 8;
+    data += step;
+  }
+}
+
+// Mirror Get16x8Block_C but pixel stride is 4 (not 3): 2 px = 8 bytes (was 6),
+// and the second 8-wide half starts at 4*8 (was 3*8).
+static void Get16x8Block_BGRA_C(const uint8_t* src1, int src_stride,
+                                int16_t yblock[4 * 64],
+                                int16_t uvblock[2 * 64]) {
+  for (int yy = 8; yy > 0; yy -= 2) {
+    const uint8_t* const src2 = src1 + src_stride;
+    for (int x = 0; x < 4; ++x) {
+      int rgb[2][3];
+      memset(rgb, 0, sizeof(rgb));
+      uint8_t t[3];
+      BgraToRgb(src1 + 8 * x, t);
+      yblock[2 * x] = ToY(t, rgb[0]);
+      BgraToRgb(src1 + 8 * x + 4, t);
+      yblock[2 * x + 1] = ToY(t, rgb[0]);
+      BgraToRgb(src2 + 8 * x, t);
+      yblock[2 * x + 8] = ToY(t, rgb[0]);
+      BgraToRgb(src2 + 8 * x + 4, t);
+      yblock[2 * x + 9] = ToY(t, rgb[0]);
+      uvblock[0 * 64 + x] = ToU(rgb[0]);
+      uvblock[1 * 64 + x] = ToV(rgb[0]);
+      BgraToRgb(src1 + 4 * 8 + 8 * x, t);
+      yblock[2 * x + 64] = ToY(t, rgb[1]);
+      BgraToRgb(src1 + 4 * 8 + 8 * x + 4, t);
+      yblock[2 * x + 1 + 64] = ToY(t, rgb[1]);
+      BgraToRgb(src2 + 4 * 8 + 8 * x, t);
+      yblock[2 * x + 8 + 64] = ToY(t, rgb[1]);
+      BgraToRgb(src2 + 4 * 8 + 8 * x + 4, t);
+      yblock[2 * x + 9 + 64] = ToY(t, rgb[1]);
+      uvblock[0 * 64 + x + 4] = ToU(rgb[1]);
+      uvblock[1 * 64 + x + 4] = ToV(rgb[1]);
+    }
+    yblock += 2 * 8;
+    uvblock += 8;
+    src1 += 2 * src_stride;
+  }
+}
+
+static void Get16x16Block_BGRA_C(const uint8_t* rgb, int step, int16_t* yuv) {
+  Get16x8Block_BGRA_C(rgb + 0 * step, step, yuv + 0 * 64, yuv + 4 * 64 + 0 * 8);
+  Get16x8Block_BGRA_C(rgb + 8 * step, step, yuv + 2 * 64, yuv + 4 * 64 + 4 * 8);
+}
+
+// Copy an RGBA pixel into an RGB triplet (alpha dropped).
+static inline void RgbaToRgb(const uint8_t* p, uint8_t rgb[3]) {
+  rgb[0] = p[0];
+  rgb[1] = p[1];
+  rgb[2] = p[2];
+}
+
+static void Get8x8Block_RGBA_C(const uint8_t* data, int step, int16_t* out) {
+  for (int y = 8; y > 0; --y) {
+    for (int x = 0; x < 8; ++x) {
+      uint8_t rgb[3];
+      RgbaToRgb(data + 4 * x, rgb);
+      ToYUV(rgb, out + x);
+    }
+    out += 8;
+    data += step;
+  }
+}
+
+static void Get8x8Block_Y_RGBA_C(const uint8_t* data, int step, int16_t* out) {
+  for (int y = 8; y > 0; --y) {
+    for (int x = 0; x < 8; ++x) {
+      uint8_t rgb[3];
+      RgbaToRgb(data + 4 * x, rgb);
+      out[x] = ToY(rgb);
+    }
+    out += 8;
+    data += step;
+  }
+}
+
+static void Get16x8Block_RGBA_C(const uint8_t* src1, int src_stride,
+                                int16_t yblock[4 * 64],
+                                int16_t uvblock[2 * 64]) {
+  for (int yy = 8; yy > 0; yy -= 2) {
+    const uint8_t* const src2 = src1 + src_stride;
+    for (int x = 0; x < 4; ++x) {
+      int rgb[2][3];
+      memset(rgb, 0, sizeof(rgb));
+      uint8_t t[3];
+      RgbaToRgb(src1 + 8 * x, t);
+      yblock[2 * x] = ToY(t, rgb[0]);
+      RgbaToRgb(src1 + 8 * x + 4, t);
+      yblock[2 * x + 1] = ToY(t, rgb[0]);
+      RgbaToRgb(src2 + 8 * x, t);
+      yblock[2 * x + 8] = ToY(t, rgb[0]);
+      RgbaToRgb(src2 + 8 * x + 4, t);
+      yblock[2 * x + 9] = ToY(t, rgb[0]);
+      uvblock[0 * 64 + x] = ToU(rgb[0]);
+      uvblock[1 * 64 + x] = ToV(rgb[0]);
+      RgbaToRgb(src1 + 4 * 8 + 8 * x, t);
+      yblock[2 * x + 64] = ToY(t, rgb[1]);
+      RgbaToRgb(src1 + 4 * 8 + 8 * x + 4, t);
+      yblock[2 * x + 1 + 64] = ToY(t, rgb[1]);
+      RgbaToRgb(src2 + 4 * 8 + 8 * x, t);
+      yblock[2 * x + 8 + 64] = ToY(t, rgb[1]);
+      RgbaToRgb(src2 + 4 * 8 + 8 * x + 4, t);
+      yblock[2 * x + 9 + 64] = ToY(t, rgb[1]);
+      uvblock[0 * 64 + x + 4] = ToU(rgb[1]);
+      uvblock[1 * 64 + x + 4] = ToV(rgb[1]);
+    }
+    yblock += 2 * 8;
+    uvblock += 8;
+    src1 += 2 * src_stride;
+  }
+}
+
+static void Get16x16Block_RGBA_C(const uint8_t* rgb, int step, int16_t* yuv) {
+  Get16x8Block_RGBA_C(rgb + 0 * step, step, yuv + 0 * 64, yuv + 4 * 64 + 0 * 8);
+  Get16x8Block_RGBA_C(rgb + 8 * step, step, yuv + 2 * 64, yuv + 4 * 64 + 4 * 8);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
-RGBToYUVBlockFunc GetBlockFunc(SjpegYUVMode yuv_mode) {
+RGBToYUVBlockFunc GetBlockFunc(SjpegYUVMode yuv_mode, PixelFormat fmt) {
+  if (fmt == kBGRAInput) {
+#if defined(SJPEG_USE_SSE2)
+    if (SupportsSSE2())
+      return (yuv_mode == SJPEG_YUV_444)   ? Get8x8Block_BGRA_SSE2
+             : (yuv_mode == SJPEG_YUV_420) ? Get16x16Block_BGRA_SSE2
+                                           : Get8x8Block_Y_BGRA_SSE2;
+#elif defined(SJPEG_USE_NEON)
+    if (SupportsNEON())
+      return (yuv_mode == SJPEG_YUV_444)   ? Get8x8Block_BGRA_NEON
+             : (yuv_mode == SJPEG_YUV_420) ? Get16x16Block_BGRA_NEON
+                                           : Get8x8Block_Y_BGRA_NEON;
+#endif
+    return (yuv_mode == SJPEG_YUV_444)   ? Get8x8Block_BGRA_C
+           : (yuv_mode == SJPEG_YUV_420) ? Get16x16Block_BGRA_C
+                                         : Get8x8Block_Y_BGRA_C;
+  }
+  if (fmt == kRGBAInput) {
+#if defined(SJPEG_USE_SSE2)
+    if (SupportsSSE2())
+      return (yuv_mode == SJPEG_YUV_444)   ? Get8x8Block_RGBA_SSE2
+             : (yuv_mode == SJPEG_YUV_420) ? Get16x16Block_RGBA_SSE2
+                                           : Get8x8Block_Y_RGBA_SSE2;
+#elif defined(SJPEG_USE_NEON)
+    if (SupportsNEON())
+      return (yuv_mode == SJPEG_YUV_444)   ? Get8x8Block_RGBA_NEON
+             : (yuv_mode == SJPEG_YUV_420) ? Get16x16Block_RGBA_NEON
+                                           : Get8x8Block_Y_RGBA_NEON;
+#endif
+    return (yuv_mode == SJPEG_YUV_444)   ? Get8x8Block_RGBA_C
+           : (yuv_mode == SJPEG_YUV_420) ? Get16x16Block_RGBA_C
+                                         : Get8x8Block_Y_RGBA_C;
+  }
 #if defined(SJPEG_USE_SSE2)
   if (SupportsSSE2()) return (yuv_mode == SJPEG_YUV_444) ? Get8x8Block_SSE2 :
                              (yuv_mode == SJPEG_YUV_420) ? Get16x16Block_SSE2 :

--- a/src/colors_rgb.cc
+++ b/src/colors_rgb.cc
@@ -22,7 +22,6 @@
 
 #include <string.h>
 
-#include "sjpeg.h"
 #define SJPEG_NEED_ASM_HEADERS
 #include "sjpegi.h"
 

--- a/src/enc.cc
+++ b/src/enc.cc
@@ -17,12 +17,13 @@
 // Author: Skal (pascal.massimino@gmail.com)
 
 #include <assert.h>
-#include <stdlib.h>
+#include <float.h>  // for FLT_MAX
 #include <math.h>
-#include <float.h>    // for FLT_MAX
 #include <stdint.h>
+#include <stdlib.h>
 
 #include <cstdlib>
+#include <memory>
 #include <mutex>  // NOLINT
 #include <new>
 
@@ -1821,7 +1822,8 @@ const uint8_t* Encoder::GetReplicatedSamples(const uint8_t* rgb,
                                              int rgb_step,
                                              int sub_w, int sub_h,
                                              int w, int h) {
-  Replicate8b(rgb, rgb_step, replicated_buffer_, 3 * w, sub_w, sub_h, w, h, 3);
+  Replicate8b(rgb, rgb_step, replicated_buffer_, pix_step_ * w, sub_w, sub_h, w,
+              h, pix_step_);
   return replicated_buffer_;
 }
 
@@ -1851,18 +1853,22 @@ bool FinishEncoding(Encoder* const enc, const EncoderParam& param) {
 class Encoder420 final : public Encoder {
  public:
   Encoder420(int W, int H, const uint8_t* const rgb, int step,
-             ByteSink* const sink)
+             ByteSink* const sink, PixelFormat fmt = kRGBInput)
       : Encoder(SJPEG_YUV_420, W, H, sink), rgb_(rgb), step_(step) {
     ok_ = (rgb != nullptr);
+    if (fmt != kRGBInput) {
+      pix_step_ = 4;
+      get_yuv_block_ = GetBlockFunc(yuv_mode_, fmt);
+    }
   }
   virtual ~Encoder420() {}
   virtual void GetSamples(int mb_x, int mb_y, bool clipped, int16_t* out) {
-    const uint8_t* rgb = rgb_ + (3 * mb_x + mb_y * step_) * 16;
+    const uint8_t* rgb = rgb_ + (pix_step_ * mb_x + mb_y * step_) * 16;
     int step = step_;
     if (clipped) {
       rgb = GetReplicatedSamples(rgb, step,
                                  W_ - mb_x * 16, H_ - mb_y * 16, 16, 16);
-      step = 3 * 16;
+      step = pix_step_ * 16;
     }
     get_yuv_block_(rgb, step, out);
     if (clipped) {
@@ -1881,19 +1887,23 @@ class Encoder420 final : public Encoder {
 class Encoder444 final : public Encoder {
  public:
   Encoder444(int W, int H, const uint8_t* const rgb, int step,
-             ByteSink* const sink)
+             ByteSink* const sink, PixelFormat fmt = kRGBInput)
       : Encoder(SJPEG_YUV_444, W, H, sink), rgb_(rgb), step_(step) {
     ok_ = (rgb != nullptr);
+    if (fmt != kRGBInput) {
+      pix_step_ = 4;
+      get_yuv_block_ = GetBlockFunc(yuv_mode_, fmt);
+    }
   }
   virtual ~Encoder444() {}
 
   virtual void GetSamples(int mb_x, int mb_y, bool clipped, int16_t* out) {
-    const uint8_t* rgb = rgb_ + (3 * mb_x + mb_y * step_) * 8;
+    const uint8_t* rgb = rgb_ + (pix_step_ * mb_x + mb_y * step_) * 8;
     int step = step_;
     if (clipped) {
       rgb = GetReplicatedSamples(rgb, step,
                                  W_ - mb_x * 8, H_ - mb_y * 8, 8, 8);
-      step = 3 * 8;
+      step = pix_step_ * 8;
     }
     get_yuv_block_(rgb, step, out);
   }
@@ -1909,19 +1919,23 @@ class Encoder444 final : public Encoder {
 class Encoder400 final : public Encoder {
  public:
   Encoder400(int W, int H, const uint8_t* const src, int step,
-             ByteSink* const sink)
+             ByteSink* const sink, PixelFormat fmt = kRGBInput)
       : Encoder(SJPEG_YUV_400, W, H, sink), rgb_(src), step_(step) {
     ok_ = (src != nullptr);
+    if (fmt != kRGBInput) {
+      pix_step_ = 4;
+      get_yuv_block_ = GetBlockFunc(yuv_mode_, fmt);
+    }
   }
   virtual ~Encoder400() {}
 
   virtual void GetSamples(int mb_x, int mb_y, bool clipped, int16_t* out) {
-    const uint8_t* rgb = rgb_ + (3 * mb_x + mb_y * step_) * 8;
+    const uint8_t* rgb = rgb_ + (pix_step_ * mb_x + mb_y * step_) * 8;
     int step = step_;
     if (clipped) {
       rgb = GetReplicatedSamples(rgb, step_,
                                  W_ - mb_x * 8, H_ - mb_y * 8, 8, 8);
-      step = 3 * 8;
+      step = pix_step_ * 8;
     }
     get_yuv_block_(rgb, step, out);
   }
@@ -2207,22 +2221,22 @@ class EncoderSharp420 final : public EncoderYUV420 {
 ////////////////////////////////////////////////////////////////////////////////
 // all-in-one factory to pickup the right encoder instance
 
-Encoder* EncoderFactory(const uint8_t* rgb,
-                        int W, int H, int stride, SjpegYUVMode yuv_mode,
-                        ByteSink* const sink) {
+Encoder* EncoderFactory(const uint8_t* rgb, int W, int H, int stride,
+                        SjpegYUVMode yuv_mode, ByteSink* const sink,
+                        PixelFormat fmt = kRGBInput) {
   if (yuv_mode == SJPEG_YUV_AUTO) {
     yuv_mode = SjpegRiskiness(rgb, W, H, stride, nullptr);
   }
 
   Encoder* enc = nullptr;
   if (yuv_mode == SJPEG_YUV_420) {
-    enc = new (std::nothrow) Encoder420(W, H, rgb, stride, sink);
+    enc = new (std::nothrow) Encoder420(W, H, rgb, stride, sink, fmt);
   } else if (yuv_mode == SJPEG_YUV_SHARP) {
     enc = new (std::nothrow) EncoderSharp420(W, H, rgb, stride, sink);
   } else if (yuv_mode == SJPEG_YUV_444) {
-    enc = new (std::nothrow) Encoder444(W, H, rgb, stride, sink);
+    enc = new (std::nothrow) Encoder444(W, H, rgb, stride, sink, fmt);
   } else if (yuv_mode == SJPEG_YUV_400) {
-    enc = new (std::nothrow) Encoder400(W, H, rgb, stride, sink);
+    enc = new (std::nothrow) Encoder400(W, H, rgb, stride, sink, fmt);
   }
   if (enc == nullptr || !enc->Ok()) {
     delete enc;
@@ -2405,6 +2419,60 @@ size_t Encode(const uint8_t* rgb, int width, int height, int stride,
   return size;
 }
 
+bool EncodeBGRA(const uint8_t* bgra, int width, int height, int stride,
+                const EncoderParam& param, ByteSink* sink) {
+  if (bgra == nullptr || sink == nullptr) return false;
+  if (width <= 0 || height <= 0 || std::abs(stride) < 4 * width) return false;
+  const SjpegYUVMode mode = param.yuv_mode;
+  if (mode == SJPEG_YUV_AUTO || mode == SJPEG_YUV_SHARP) {
+    // Fallback: convert to a scratch RGB plane and reuse the RGB path.
+    const int rgb_stride = 3 * width;
+    std::unique_ptr<uint8_t[]> rgb(new (std::nothrow)
+                                       uint8_t[(size_t)rgb_stride * height]);
+    if (rgb == nullptr) return false;
+    for (int y = 0; y < height; ++y) {
+      const uint8_t* s = bgra + (size_t)y * stride;
+      uint8_t* d = rgb.get() + (size_t)y * rgb_stride;
+      for (int x = 0; x < width; ++x, s += 4, d += 3) {
+        d[0] = s[2];
+        d[1] = s[1];
+        d[2] = s[0];
+      }
+    }
+    return Encode(rgb.get(), width, height, rgb_stride, param, sink);
+  }
+  Encoder* const enc =
+      EncoderFactory(bgra, width, height, stride, mode, sink, kBGRAInput);
+  return FinishEncoding(enc, param);
+}
+
+bool EncodeRGBA(const uint8_t* rgba, int width, int height, int stride,
+                const EncoderParam& param, ByteSink* sink) {
+  if (rgba == nullptr || sink == nullptr) return false;
+  if (width <= 0 || height <= 0 || std::abs(stride) < 4 * width) return false;
+  const SjpegYUVMode mode = param.yuv_mode;
+  if (mode == SJPEG_YUV_AUTO || mode == SJPEG_YUV_SHARP) {
+    // Fallback: convert to a scratch RGB plane and reuse the RGB path.
+    const int rgb_stride = 3 * width;
+    std::unique_ptr<uint8_t[]> rgb(new (std::nothrow)
+                                       uint8_t[(size_t)rgb_stride * height]);
+    if (rgb == nullptr) return false;
+    for (int y = 0; y < height; ++y) {
+      const uint8_t* s = rgba + (size_t)y * stride;
+      uint8_t* d = rgb.get() + (size_t)y * rgb_stride;
+      for (int x = 0; x < width; ++x, s += 4, d += 3) {
+        d[0] = s[0];
+        d[1] = s[1];
+        d[2] = s[2];
+      }
+    }
+    return Encode(rgb.get(), width, height, rgb_stride, param, sink);
+  }
+  Encoder* const enc =
+      EncoderFactory(rgba, width, height, stride, mode, sink, kRGBAInput);
+  return FinishEncoding(enc, param);
+}
+
 bool EncodeGray(const uint8_t* gray, int width, int height, int stride,
                 const EncoderParam& param, ByteSink* sink) {
   if (gray == nullptr || sink == nullptr) return false;
@@ -2425,6 +2493,24 @@ bool Encode(const uint8_t* rgb, int width, int height, int stride,
   output->reserve(width * height / 4);
   StringSink sink(output);
   return Encode(rgb, width, height, stride, param, &sink);
+}
+
+bool EncodeBGRA(const uint8_t* bgra, int width, int height, int stride,
+                const EncoderParam& param, std::string* output) {
+  if (output == nullptr) return false;
+  output->clear();
+  output->reserve((size_t)width * height / 4);
+  StringSink sink(output);
+  return EncodeBGRA(bgra, width, height, stride, param, &sink);
+}
+
+bool EncodeRGBA(const uint8_t* rgba, int width, int height, int stride,
+                const EncoderParam& param, std::string* output) {
+  if (output == nullptr) return false;
+  output->clear();
+  output->reserve((size_t)width * height / 4);
+  StringSink sink(output);
+  return EncodeRGBA(rgba, width, height, stride, param, &sink);
 }
 
 bool EncodeGray(const uint8_t* gray, int width, int height, int stride,

--- a/src/sjpeg.h
+++ b/src/sjpeg.h
@@ -294,6 +294,22 @@ bool Encode(const uint8_t* rgb, int width, int height, int stride,
 ////////////////////////////////////////////////////////////////////////////////
 // Ad-hoc functions for specialized cases
 
+// Encodes a packed BGRA buffer (4 bytes/pixel, byte order B,G,R,A; alpha
+// ignored) directly, without an intermediate RGB copy. 'stride' is in bytes and
+// must be >= 4*width. YUV_AUTO / YUV_SHARP fall back to an internal RGB copy.
+bool EncodeBGRA(const uint8_t* bgra, int width, int height, int stride,
+                const EncoderParam& param, sjpeg::ByteSink* sink);
+bool EncodeBGRA(const uint8_t* bgra, int width, int height, int stride,
+                const EncoderParam& param, std::string* output);
+
+// Encodes a packed RGBA buffer (4 bytes/pixel, byte order R,G,B,A; alpha
+// ignored) directly, without an intermediate RGB copy. 'stride' is in bytes and
+// must be >= 4*width. YUV_AUTO / YUV_SHARP fall back to an internal RGB copy.
+bool EncodeRGBA(const uint8_t* rgba, int width, int height, int stride,
+                const EncoderParam& param, sjpeg::ByteSink* sink);
+bool EncodeRGBA(const uint8_t* rgba, int width, int height, int stride,
+                const EncoderParam& param, std::string* output);
+
 // These function are specialized for encoding grayscale input using YUV400,
 // and behave like the generic Encode() functions above. The input samples
 // in gray[] are interpreted as the Luma samples, without transformation.

--- a/src/sjpeg.h
+++ b/src/sjpeg.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-#define SJPEG_VERSION 0x000100   // 0.1.0
+#define SJPEG_VERSION 0x000101   // 0.1.1
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -91,10 +91,14 @@ extern int YUVToRiskIdx(int16_t y, int16_t u, int16_t v);
 ///////////////////////////////////////////////////////////////////////////////
 // RGB->YUV conversion
 
+// Internal pixel format for the input samples fed to the block functions.
+enum PixelFormat { kRGBInput = 0, kBGRAInput = 1, kRGBAInput = 2 };
+
 // convert 16x16 RGB block into YUV420, or 8x8 RGB block into YUV444 or YUV400
 typedef void (*RGBToYUVBlockFunc)(const uint8_t* src, int src_stride,
                                   int16_t* blocks);
-extern RGBToYUVBlockFunc GetBlockFunc(SjpegYUVMode mode);
+extern RGBToYUVBlockFunc GetBlockFunc(SjpegYUVMode mode,
+                                      PixelFormat fmt = kRGBInput);
 
 // convert a row of RGB samples to YUV444
 typedef void (*RGBToIndexRowFunc)(const uint8_t* src, int width,
@@ -339,7 +343,8 @@ struct Encoder {
                                        int sub_w, int sub_h);
   // set blocks that are totally outside of the picture to an average value
   void AverageExtraLuma(int sub_w, int sub_h, int16_t* out);
-  uint8_t replicated_buffer_[3 * 16 * 16];   // tmp buffer for replication
+  uint8_t replicated_buffer_[4 * 16 * 16];  // tmp buffer for replication
+  int pix_step_ = 3;  // bytes per input pixel (3=RGB, 4=BGRA/RGBA)
 
   sjpeg::RGBToYUVBlockFunc get_yuv_block_;  // set by GetBlockFunc()
   bool adaptive_bias_;   // if true, use per-block perceptual bias modulation

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -19,7 +19,7 @@
 #ifndef SJPEG_JPEGI_H_
 #define SJPEG_JPEGI_H_
 
-#include "sjpeg.h"
+#include "sjpeg.h"  // IWYU pragma: export
 #include "bit_writer.h"
 
 #ifndef NULL


### PR DESCRIPTION
- Adds kBGRAInput and kRGBAInput to PixelFormat in sjpegi.h.
- Implements optimized SSE2, NEON, and C scalar block converters in colors_rgb.cc for direct packed 32-bit pixel (BGRA and RGBA) to YUV conversion, dropping alpha on the fly without intermediate RGB copies.
- Exposes sjpeg::EncodeBGRA() and sjpeg::EncodeRGBA() overloads (ByteSink* and std::string*) in sjpeg.h and enc.cc under ad-hoc specialized functions.