### PR TITLE
Misc fixes and improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: cmake .
       - run: cmake --build .
+      - run: ctest --output-on-failure
 
   macos:
     runs-on: macos-latest
@@ -15,6 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: cmake .
       - run: cmake --build .
+      - run: ctest --output-on-failure
 
   android:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,16 @@
 name: Build
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+        with:
+          persist-credentials: false
       - run: cmake .
       - run: cmake --build .
       - run: ctest --output-on-failure
@@ -13,7 +18,9 @@ jobs:
   macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+        with:
+          persist-credentials: false
       - run: cmake .
       - run: cmake --build .
       - run: ctest --output-on-failure
@@ -21,7 +28,9 @@ jobs:
   android:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+        with:
+          persist-credentials: false
       - run: mkdir build && cd build
       - run: cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/android.cmake -DSJPEG_ANDROID_NDK_PATH=$ANDROID_NDK_LATEST_HOME
         working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,10 @@ endif()
 if(SJPEG_BUILD_TESTS)
   enable_testing()
   add_executable(unit_test ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit_test.cc)
-  target_link_libraries(unit_test sjpeg)
+  # the tests encode from several threads at once
+  set(THREADS_PREFER_PTHREAD_FLAG ON)
+  find_package(Threads REQUIRED)
+  target_link_libraries(unit_test sjpeg Threads::Threads)
   add_test(NAME unit_test COMMAND unit_test)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(CMAKE_CXX_STANDARD 11)
 # Options for coder / decoder executables.
 option(SJPEG_ENABLE_SIMD "Enable any SIMD optimization." ON)
 option(SJPEG_BUILD_EXAMPLES "Build the sjpeg / vjpeg command line tools." ON)
+option(SJPEG_BUILD_TESTS "Build the unit tests." ON)
 
 set(SJPEG_DEP_LIBRARIES)
 set(SJPEG_DEP_INCLUDE_DIRS)
@@ -196,6 +197,14 @@ if(SJPEG_BUILD_EXAMPLES)
   target_link_libraries(vjpeg ${SJPEG_DEP_GL_LIBRARIES} sjpeg sjpeg-utils)
 
   install(TARGETS sjpeg-bin vjpeg RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
+
+# Build the unit tests if asked for.
+if(SJPEG_BUILD_TESTS)
+  enable_testing()
+  add_executable(unit_test ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit_test.cc)
+  target_link_libraries(unit_test sjpeg)
+  add_test(NAME unit_test COMMAND unit_test)
 endif()
 
 # Install the different headers and libraries.

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,13 @@ HDRS = \
 OUT_LIBS = src/libsjpeg.a examples/libutils.a
 OUT_EXAMPLES =  examples/sjpeg
 OUT_EXAMPLES += examples/vjpeg
+OUT_TESTS = tests/unit_test
 
-OUTPUT = $(OUT_LIBS) $(OUT_EXAMPLES)
+OUTPUT = $(OUT_LIBS) $(OUT_EXAMPLES) $(OUT_TESTS)
+
+# Without this, the built-in '%: %.o' rule takes over 'unit_test' and links it
+# with $(CC) instead of running it.
+.PHONY: all clean dist ex install test test_cmd test_png_jpg unit_test
 
 ex: $(OUT_EXAMPLES)
 all: ex
@@ -135,7 +140,16 @@ examples/vjpeg: EXTRA_FLAGS += -DSJPEG_HAVE_OPENGL
 $(OUT_EXAMPLES):
 	$(CXX) -o $@ $^ $(LDFLAGS)
 
-test: test_cmd test_png_jpg
+tests/unit_test: tests/unit_test.o
+tests/unit_test: src/libsjpeg.a
+
+$(OUT_TESTS):
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+test: unit_test test_cmd test_png_jpg
+
+unit_test: $(OUT_TESTS)
+	./tests/unit_test
 
 test_cmd: $(OUT_EXAMPLES)
 	cd tests && ./test_cmd.sh
@@ -161,7 +175,8 @@ dist: all
 
 clean:
 	$(RM) $(OUTPUT) *~ \
-              examples/*.o examples/*~ man/*~ src/*.o src/*~ tests/*~ \
+              examples/*.o examples/*~ man/*~ src/*.o src/*~ \
+              tests/*.o tests/*~ \
               examples/*.lo src/*.lo
 
 DIST_FILES= \
@@ -202,6 +217,7 @@ DIST_FILES= \
          examples/utils.cc  \
          tests/test_cmd.sh  \
          tests/test_png_jpg.sh  \
+         tests/unit_test.cc  \
          tests/testdata/source1.png \
          tests/testdata/source1.itl.png \
          tests/testdata/source2.jpg \

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,8 @@ $(OUT_EXAMPLES):
 
 tests/unit_test: tests/unit_test.o
 tests/unit_test: src/libsjpeg.a
+# the tests encode from several threads at once
+tests/unit_test: EXTRA_LIBS += -lpthread
 
 $(OUT_TESTS):
 	$(CXX) -o $@ $^ $(LDFLAGS)

--- a/src/bit_writer.cc
+++ b/src/bit_writer.cc
@@ -95,6 +95,13 @@ BitWriter::BitWriter(ByteSink* const sink) : sink_(sink), buf_(nullptr) {
   byte_pos_ = 0;
 }
 
+bool BitWriter::CommitFailed() {
+  sink_->Reset();   // this can free the memory buf_ points to
+  buf_ = nullptr;
+  byte_pos_ = 0;
+  return false;
+}
+
 void BitWriter::Flush() {
   // align and pad the bitstream
   // nb_pad is the number of '1' bits we need to insert to reach a byte-aligned
@@ -109,6 +116,7 @@ void BitWriter::Flush() {
 ///////////////////////////////////////////////////////////////////////////////
 
 void BitCounter::AddBits(const uint32_t bits, size_t nbits) {
+  assert(nbits > 0);
   size_ += nbits;
   bit_pos_ += nbits;
   bits_ |= bits << (32 - bit_pos_);

--- a/src/bit_writer.h
+++ b/src/bit_writer.h
@@ -87,10 +87,9 @@ class BitWriter {
   // Verifies the that output buffer can store at least 'size' more bytes.
   // Also flushes the previously written data.
   bool Reserve(size_t size) {
-    const bool ok = sink_->Commit(byte_pos_, size, &buf_);
-    if (!ok) sink_->Reset();
+    if (!sink_->Commit(byte_pos_, size, &buf_)) return CommitFailed();
     byte_pos_ = 0;
-    return ok;
+    return true;
   }
 
   // Make sure we can write 24 bits by flushing the past ones.
@@ -145,6 +144,8 @@ class BitWriter {
   bool Finalize() { return Reserve(0) && sink_->Finalize(); }
 
  private:
+  bool CommitFailed();
+
   ByteSink* sink_;
 
   int nb_bits_;      // number of unwritten bits

--- a/src/dichotomy.cc
+++ b/src/dichotomy.cc
@@ -215,7 +215,7 @@ size_t Encoder::HeaderSize() const {
       size += (xmp_.size() / 65458 + 1) * 40;
     }
   }
-  size += 2 * 65 + 2 + 2;         // DQT
+  size += (nb_comps_ == 1 ? 1 : 2) * 65 + 2 + 2;  // DQT
   size += 8 + 3 * nb_comps_ + 2;  // SOF
   size += 6 + 2 * nb_comps_ + 2;  // SOS
   size += 2;                      // EOI

--- a/src/dichotomy.cc
+++ b/src/dichotomy.cc
@@ -88,7 +88,7 @@ void Encoder::StoreRunLevels(DCTCoeffs* coeffs) {
   nb_run_levels_ = 0;
   int16_t* in = in_blocks_;
   for (int n = 0; n < mb_w_ * mb_h_; ++n) {
-    CheckBuffers();
+    if (!CheckBuffers()) return;
     for (int c = 0; c < nb_comps_; ++c) {
       for (int i = 0; i < nb_blocks_[c]; ++i) {
         RunLevel* const run_levels = all_run_levels_ + nb_run_levels_;
@@ -139,6 +139,7 @@ void Encoder::LoopScan() {
     if (search_hook_->for_size) {
       // compute pass to store coeffs / runs / dc_code_
       StoreRunLevels(base_coeffs);
+      if (!ok_) break;
       if (optimize_size_) {
         StoreOptimalHuffmanTables(nb_mbs, base_coeffs);
         if (use_trellis_) InitCodes(true);
@@ -176,18 +177,19 @@ void Encoder::LoopScan() {
   // optimize Huffman table now, if we haven't already during the search
   if (!search_hook_->for_size || !last_is_best) {
     StoreRunLevels(base_coeffs);
-    if (optimize_size_) {
+    if (ok_ && optimize_size_) {
       StoreOptimalHuffmanTables(nb_mbs, base_coeffs);
     }
   }
 
   // finish bitstream
-  WriteDQT();
-  WriteSOF();
-  WriteDHT();
-  WriteSOS();
-  FinalPassScan(nb_mbs, base_coeffs);
-
+  if (ok_) {
+    WriteDQT();
+    WriteSOF();
+    WriteDHT();
+    WriteSOS();
+    FinalPassScan(nb_mbs, base_coeffs);
+  }
   Free(base_coeffs);
 }
 

--- a/src/dichotomy.cc
+++ b/src/dichotomy.cc
@@ -16,6 +16,7 @@
 //
 // Author: Skal (pascal.massimino@gmail.com)
 
+#include <assert.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -166,29 +167,33 @@ void Encoder::LoopScan() {
     }
     if (search_hook_->Update(result)) break;
   }
-  // transfer back the final matrices
-  SetQuantMatrices(opt_quants);
-  for (int c = 0; c < 2; ++c) FinalizeQuantMatrix(&quants_[c], q_bias_);
-
-  // return informative values to the user
-  search_hook_->q = best_q;
-  search_hook_->value = best_result;
-
-  // optimize Huffman table now, if we haven't already during the search
-  if (!search_hook_->for_size || !last_is_best) {
-    StoreRunLevels(base_coeffs);
-    if (ok_ && optimize_size_) {
-      StoreOptimalHuffmanTables(nb_mbs, base_coeffs);
-    }
-  }
-
-  // finish bitstream
+  // If the search was interrupted by a failed allocation, opt_quants[] was
+  // never filled in: there is nothing to transfer back, and nothing to write.
   if (ok_) {
-    WriteDQT();
-    WriteSOF();
-    WriteDHT();
-    WriteSOS();
-    FinalPassScan(nb_mbs, base_coeffs);
+    // transfer back the final matrices
+    SetQuantMatrices(opt_quants);
+    for (int c = 0; c < 2; ++c) FinalizeQuantMatrix(&quants_[c], q_bias_);
+
+    // return informative values to the user
+    search_hook_->q = best_q;
+    search_hook_->value = best_result;
+
+    // optimize Huffman table now, if we haven't already during the search
+    if (!search_hook_->for_size || !last_is_best) {
+      StoreRunLevels(base_coeffs);
+      if (ok_ && optimize_size_) {
+        StoreOptimalHuffmanTables(nb_mbs, base_coeffs);
+      }
+    }
+
+    // finish bitstream
+    if (ok_) {
+      WriteDQT();
+      WriteSOF();
+      WriteDHT();
+      WriteSOS();
+      FinalPassScan(nb_mbs, base_coeffs);
+    }
   }
   Free(base_coeffs);
 }

--- a/src/enc.cc
+++ b/src/enc.cc
@@ -2154,7 +2154,7 @@ class EncoderYUV420 : public Encoder {
     if (clipped) {
       const int sub_w = ((W_ + 1) >> 1) - mb_x * 8;
       const int sub_h = ((H_ + 1) >> 1) - mb_y * 8;
-      Convert8To16bClipped(U, v_step_, out + 4 * 64, sub_w, sub_h);
+      Convert8To16bClipped(U, u_step_, out + 4 * 64, sub_w, sub_h);
       Convert8To16bClipped(V, v_step_, out + 5 * 64, sub_w, sub_h);
     } else {
       Convert8To16b(U, u_step_, out + 4 * 64);

--- a/src/enc.cc
+++ b/src/enc.cc
@@ -1678,7 +1678,9 @@ bool Encoder::Encode() {
   assert(nb_comps_ <= MAX_COMP);
   assert(mcu_blocks_ <= 6);
   // validate some input parameters
-  if (W_ <= 0 || H_ <= 0) return false;
+  if (W_ <= 0 || H_ <= 0 || W_ > kMaxDimension || H_ > kMaxDimension) {
+    return SetError();
+  }
 
   mb_w_ = (W_ + (block_w_ - 1)) / block_w_;
   mb_h_ = (H_ + (block_h_ - 1)) / block_h_;

--- a/src/enc.cc
+++ b/src/enc.cc
@@ -1976,11 +1976,7 @@ class EncoderNV12 final : public Encoder {
               int W, int H, ByteSink* const sink, bool is_nv12)
       : Encoder(SJPEG_YUV_420, W, H, sink),
         y_(y), y_step_(y_step), uv_(uv), uv_step_(uv_step), is_nv12_(is_nv12) {
-    ok_ = (y_ != nullptr) && (uv_ != nullptr) &&
-          (W > 0) && (H > 0) &&
-          (std::abs(y_step) >= W) &&
-          (std::abs(uv_step) >= (W + 1) / 2) &&
-          (sink != nullptr);
+    assert(sink != nullptr);
   }
 
   virtual void GetSamples(int mb_x, int mb_y, bool clipped, int16_t* out) {
@@ -2038,15 +2034,29 @@ class EncoderNV12 final : public Encoder {
   bool is_nv12_;
 };
 
+// Common implementation for NV12 (U/V/U/V...) and NV21 (V/U/V/U...).
+// Arguments are checked here: the base class uses 'output' at construction.
+static bool EncodeNV(const uint8_t* y, int y_stride,
+                     const uint8_t* uv, int uv_stride,
+                     int width, int height, bool is_nv12,
+                     const EncoderParam& param, ByteSink* output) {
+  if (y == nullptr || uv == nullptr || output == nullptr) return false;
+  if (width <= 0 || height <= 0) return false;
+  if (std::abs(y_stride) < width) return false;
+  if (std::abs(uv_stride) < 2 * ((width + 1) / 2)) return false;
+  Encoder* const enc =
+      new (std::nothrow) EncoderNV12(y, y_stride, uv, uv_stride,
+                                     width, height, output, is_nv12);
+  return FinishEncoding(enc, param);
+}
+
 // Encode from NV12 samples, using YUV420 format
 bool EncodeNV12(const uint8_t* y, int y_stride,
                 const uint8_t* uv, int uv_stride,
                 int width, int height,
                 const EncoderParam& param, ByteSink* output) {
-  Encoder* const enc =
-      new (std::nothrow) EncoderNV12(y, y_stride, uv, uv_stride,
-                                     width, height, output, true);
-  return FinishEncoding(enc, param);
+  return EncodeNV(y, y_stride, uv, uv_stride, width, height, true,
+                  param, output);
 }
 
 // Encode from NV21 samples, using YUV420 format
@@ -2054,10 +2064,8 @@ bool EncodeNV21(const uint8_t* y, int y_stride,
                 const uint8_t* vu, int vu_stride,
                 int width, int height,
                 const EncoderParam& param, ByteSink* output) {
-  Encoder* const enc =
-      new (std::nothrow) EncoderNV12(y, y_stride, vu, vu_stride,
-                                     width, height, output, false);
-  return FinishEncoding(enc, param);
+  return EncodeNV(y, y_stride, vu, vu_stride, width, height, false,
+                  param, output);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/enc.cc
+++ b/src/enc.cc
@@ -2260,10 +2260,10 @@ size_t SjpegEncode(const uint8_t* rgb, int width, int height, int stride,
   MemorySink sink(width * height / 4);
   Encoder* const enc = EncoderFactory(rgb, width, height, stride, yuv_mode,
                                       &sink);
+  if (enc == nullptr) return 0;
   enc->SetQuality(quality);
   enc->SetCompressionMethod(method);
   size_t size = 0;
-  *out_data = nullptr;
   if (enc->Encode()) sink.Release(out_data, &size);
   delete enc;
   return size;

--- a/src/enc.cc
+++ b/src/enc.cc
@@ -213,7 +213,7 @@ void Encoder::SetDefaultMinQuantMatrices() {
 }
 
 void Encoder::SetCompressionMethod(int method) {
-  assert(method >= 0 && method <= 8);
+  method = (method < 0) ? 0 : (method > 8) ? 8 : method;
   use_adaptive_quant_ = (method >= 3);
   optimize_size_ = (method != 0) && (method != 3);
   use_extra_memory_ = (method == 3) || (method == 4) || (method == 7);

--- a/src/enc.cc
+++ b/src/enc.cc
@@ -21,11 +21,15 @@
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>  // for memcpy / memset
 
 #include <cstdlib>
 #include <memory>
 #include <mutex>  // NOLINT
 #include <new>
+#include <string>
+
+#include "bit_writer.h"
 
 #define SJPEG_NEED_ASM_HEADERS
 #include "sjpegi.h"
@@ -2216,13 +2220,15 @@ class EncoderSharp420 final : public EncoderYUV420 {
         yuv_memory_(nullptr) {
     const int uv_w = (W + 1) >> 1;
     const int uv_h = (H + 1) >> 1;
-    yuv_memory_ = Alloc<uint8_t>(W * H + 2 * uv_w * uv_h);
+    const size_t y_size = (size_t)W * H;
+    const size_t uv_size = (size_t)uv_w * uv_h;
+    yuv_memory_ = Alloc<uint8_t>(y_size + 2 * uv_size);
     ok_ = (yuv_memory_ != nullptr);
     if (ok_) {
       y_ = yuv_memory_;
       y_step_ = W;
-      u_ = yuv_memory_ + W * H;
-      v_ = u_ + uv_w * uv_h;
+      u_ = yuv_memory_ + y_size;
+      v_ = u_ + uv_size;
       u_step_ = uv_w;
       v_step_ = uv_w;
       ApplySharpYUVConversion(rgb, W, H, step,
@@ -2277,7 +2283,7 @@ size_t SjpegEncode(const uint8_t* rgb, int width, int height, int stride,
   if (width <= 0 || height <= 0 || std::abs(stride) < 3 * width) return 0;
   *out_data = nullptr;  // safety
 
-  MemorySink sink(width * height / 4);
+  MemorySink sink((size_t)width * height / 4);
   Encoder* const enc = EncoderFactory(rgb, width, height, stride, yuv_mode,
                                       &sink);
   if (enc == nullptr) return 0;
@@ -2434,7 +2440,7 @@ bool Encode(const uint8_t* rgb, int width, int height, int stride,
 
 size_t Encode(const uint8_t* rgb, int width, int height, int stride,
               const EncoderParam& param, uint8_t** out_data) {
-  MemorySink sink(width * height / 4);    // estimation of output size
+  MemorySink sink((size_t)width * height / 4);    // estimation of output size
   if (!Encode(rgb, width, height, stride, param, &sink)) return 0;
   size_t size;
   sink.Release(out_data, &size);
@@ -2513,7 +2519,7 @@ bool Encode(const uint8_t* rgb, int width, int height, int stride,
             const EncoderParam& param, std::string* output) {
   if (output == nullptr) return false;
   output->clear();
-  output->reserve(width * height / 4);
+  output->reserve((size_t)width * height / 4);
   StringSink sink(output);
   return Encode(rgb, width, height, stride, param, &sink);
 }
@@ -2540,7 +2546,7 @@ bool EncodeGray(const uint8_t* gray, int width, int height, int stride,
                 const EncoderParam& param, std::string* output) {
   if (output == nullptr) return false;
   output->clear();
-  output->reserve(width * height / 4);
+  output->reserve((size_t)width * height / 4);
   StringSink sink(output);
   return EncodeGray(gray, width, height, stride, param, &sink);
 }

--- a/src/enc.cc
+++ b/src/enc.cc
@@ -157,7 +157,8 @@ static struct DefaultMemory : public MemoryManager {
 ////////////////////////////////////////////////////////////////////////////////
 // Encoder main class
 
-Encoder::Encoder(SjpegYUVMode yuv_mode, int W, int H, ByteSink* const sink)
+Encoder::Encoder(SjpegYUVMode yuv_mode, int W, int H, ByteSink* const sink,
+                 MemoryManager* const memory)
   : yuv_mode_(yuv_mode), W_(W), H_(H),
     ok_(true),
     bw_(sink),
@@ -171,7 +172,7 @@ Encoder::Encoder(SjpegYUVMode yuv_mode, int W, int H, ByteSink* const sink)
     qdelta_max_chroma_(kDefaultDeltaMaxChroma),
     passes_(1),
     search_hook_(nullptr),
-    memory_hook_(&kDefaultMemory) {
+    memory_hook_((memory == nullptr) ? &kDefaultMemory : memory) {
   SetCompressionMethod(kDefaultMethod);
   SetQuality(kDefaultQuality);
   get_yuv_block_ = GetBlockFunc(yuv_mode_);
@@ -1853,8 +1854,9 @@ bool FinishEncoding(Encoder* const enc, const EncoderParam& param) {
 class Encoder420 final : public Encoder {
  public:
   Encoder420(int W, int H, const uint8_t* const rgb, int step,
-             ByteSink* const sink, PixelFormat fmt = kRGBInput)
-      : Encoder(SJPEG_YUV_420, W, H, sink), rgb_(rgb), step_(step) {
+             ByteSink* const sink, PixelFormat fmt = kRGBInput,
+             MemoryManager* const memory = nullptr)
+      : Encoder(SJPEG_YUV_420, W, H, sink, memory), rgb_(rgb), step_(step) {
     ok_ = (rgb != nullptr);
     if (fmt != kRGBInput) {
       pix_step_ = 4;
@@ -1887,8 +1889,9 @@ class Encoder420 final : public Encoder {
 class Encoder444 final : public Encoder {
  public:
   Encoder444(int W, int H, const uint8_t* const rgb, int step,
-             ByteSink* const sink, PixelFormat fmt = kRGBInput)
-      : Encoder(SJPEG_YUV_444, W, H, sink), rgb_(rgb), step_(step) {
+             ByteSink* const sink, PixelFormat fmt = kRGBInput,
+             MemoryManager* const memory = nullptr)
+      : Encoder(SJPEG_YUV_444, W, H, sink, memory), rgb_(rgb), step_(step) {
     ok_ = (rgb != nullptr);
     if (fmt != kRGBInput) {
       pix_step_ = 4;
@@ -1919,8 +1922,9 @@ class Encoder444 final : public Encoder {
 class Encoder400 final : public Encoder {
  public:
   Encoder400(int W, int H, const uint8_t* const src, int step,
-             ByteSink* const sink, PixelFormat fmt = kRGBInput)
-      : Encoder(SJPEG_YUV_400, W, H, sink), rgb_(src), step_(step) {
+             ByteSink* const sink, PixelFormat fmt = kRGBInput,
+             MemoryManager* const memory = nullptr)
+      : Encoder(SJPEG_YUV_400, W, H, sink, memory), rgb_(src), step_(step) {
     ok_ = (src != nullptr);
     if (fmt != kRGBInput) {
       pix_step_ = 4;
@@ -1949,8 +1953,9 @@ class Encoder400 final : public Encoder {
 class Encoder400G final : public Encoder {
  public:
   Encoder400G(int W, int H, const uint8_t* const gray, int step,
-              ByteSink* const sink)
-      : Encoder(SJPEG_YUV_400, W, H, sink), gray_(gray), step_(step) {}
+              ByteSink* const sink, MemoryManager* const memory = nullptr)
+      : Encoder(SJPEG_YUV_400, W, H, sink, memory),
+        gray_(gray), step_(step) {}
   virtual ~Encoder400G() {}
 
   virtual void GetSamples(int mb_x, int mb_y, bool clipped, int16_t* out) {
@@ -1973,8 +1978,9 @@ class Encoder400G final : public Encoder {
 class EncoderNV12 final : public Encoder {
  public:
   EncoderNV12(const uint8_t* y, int y_step, const uint8_t* uv, int uv_step,
-              int W, int H, ByteSink* const sink, bool is_nv12)
-      : Encoder(SJPEG_YUV_420, W, H, sink),
+              int W, int H, ByteSink* const sink, bool is_nv12,
+              MemoryManager* const memory = nullptr)
+      : Encoder(SJPEG_YUV_420, W, H, sink, memory),
         y_(y), y_step_(y_step), uv_(uv), uv_step_(uv_step), is_nv12_(is_nv12) {
     assert(sink != nullptr);
   }
@@ -2046,7 +2052,8 @@ static bool EncodeNV(const uint8_t* y, int y_stride,
   if (std::abs(uv_stride) < 2 * ((width + 1) / 2)) return false;
   Encoder* const enc =
       new (std::nothrow) EncoderNV12(y, y_stride, uv, uv_stride,
-                                     width, height, output, is_nv12);
+                                     width, height, output, is_nv12,
+                                     param.memory);
   return FinishEncoding(enc, param);
 }
 
@@ -2076,8 +2083,9 @@ class EncoderYUV444 final : public Encoder {
   EncoderYUV444(const uint8_t* y, int y_step,
                 const uint8_t* u, int u_step,
                 const uint8_t* v, int v_step,
-                int W, int H, ByteSink* const sink)
-      : Encoder(SJPEG_YUV_444, W, H, sink),
+                int W, int H, ByteSink* const sink,
+                MemoryManager* const memory = nullptr)
+      : Encoder(SJPEG_YUV_444, W, H, sink, memory),
         y_(y), u_(u), v_(v), y_step_(y_step), u_step_(u_step), v_step_(v_step) {
     ok_ = (y_ != nullptr) && (u_ != nullptr) && (v_ != nullptr);
   }
@@ -2121,7 +2129,7 @@ bool EncodeYUV444(const uint8_t* Y, int Y_stride,
   if (std::abs(V_stride) < width) return false;
   Encoder* const enc =
       new (std::nothrow) EncoderYUV444(Y, Y_stride, U, U_stride, V, V_stride,
-                                       width, height, output);
+                                       width, height, output, param.memory);
   return FinishEncoding(enc, param);
 }
 
@@ -2133,8 +2141,9 @@ class EncoderYUV420 : public Encoder {
   EncoderYUV420(const uint8_t* y, int y_step,
                 const uint8_t* u, int u_step,
                 const uint8_t* v, int v_step,
-                int W, int H, ByteSink* const sink)
-      : Encoder(SJPEG_YUV_420, W, H, sink),
+                int W, int H, ByteSink* const sink,
+                MemoryManager* const memory = nullptr)
+      : Encoder(SJPEG_YUV_420, W, H, sink, memory),
         y_(y), u_(u), v_(v), y_step_(y_step), u_step_(u_step), v_step_(v_step) {
     ok_ = (y_ != nullptr) && (u_ != nullptr) && (v_ != nullptr);
   }
@@ -2190,7 +2199,7 @@ bool EncodeYUV420(const uint8_t* Y, int Y_stride,
   if (std::abs(V_stride) < (width + 1) / 2) return false;
   Encoder* const enc =
       new (std::nothrow) EncoderYUV420(Y, Y_stride, U, U_stride, V, V_stride,
-                                       width, height, output);
+                                       width, height, output, param.memory);
   return FinishEncoding(enc, param);
 }
 
@@ -2200,8 +2209,8 @@ bool EncodeYUV420(const uint8_t* Y, int Y_stride,
 class EncoderSharp420 final : public EncoderYUV420 {
  public:
   EncoderSharp420(int W, int H, const uint8_t* const rgb, int step,
-                  ByteSink* const sink)
-      : EncoderYUV420(nullptr, 0, nullptr, 0, nullptr, 0, W, H, sink),
+                  ByteSink* const sink, MemoryManager* const memory = nullptr)
+      : EncoderYUV420(nullptr, 0, nullptr, 0, nullptr, 0, W, H, sink, memory),
         yuv_memory_(nullptr) {
     const int uv_w = (W + 1) >> 1;
     const int uv_h = (H + 1) >> 1;
@@ -2231,20 +2240,21 @@ class EncoderSharp420 final : public EncoderYUV420 {
 
 Encoder* EncoderFactory(const uint8_t* rgb, int W, int H, int stride,
                         SjpegYUVMode yuv_mode, ByteSink* const sink,
-                        PixelFormat fmt = kRGBInput) {
+                        PixelFormat fmt = kRGBInput,
+                        MemoryManager* const memory = nullptr) {
   if (yuv_mode == SJPEG_YUV_AUTO) {
     yuv_mode = SjpegRiskiness(rgb, W, H, stride, nullptr);
   }
 
   Encoder* enc = nullptr;
   if (yuv_mode == SJPEG_YUV_420) {
-    enc = new (std::nothrow) Encoder420(W, H, rgb, stride, sink, fmt);
+    enc = new (std::nothrow) Encoder420(W, H, rgb, stride, sink, fmt, memory);
   } else if (yuv_mode == SJPEG_YUV_SHARP) {
-    enc = new (std::nothrow) EncoderSharp420(W, H, rgb, stride, sink);
+    enc = new (std::nothrow) EncoderSharp420(W, H, rgb, stride, sink, memory);
   } else if (yuv_mode == SJPEG_YUV_444) {
-    enc = new (std::nothrow) Encoder444(W, H, rgb, stride, sink, fmt);
+    enc = new (std::nothrow) Encoder444(W, H, rgb, stride, sink, fmt, memory);
   } else if (yuv_mode == SJPEG_YUV_400) {
-    enc = new (std::nothrow) Encoder400(W, H, rgb, stride, sink, fmt);
+    enc = new (std::nothrow) Encoder400(W, H, rgb, stride, sink, fmt, memory);
   }
   if (enc == nullptr || !enc->Ok()) {
     delete enc;
@@ -2404,7 +2414,8 @@ bool Encoder::InitFromParam(const EncoderParam& param) {
     if (!search_hook_->Setup(param)) return false;
   }
 
-  memory_hook_ = (param.memory == nullptr) ? &kDefaultMemory : param.memory;
+  assert(memory_hook_ == (param.memory == nullptr ? &kDefaultMemory
+                                                  : param.memory));
   return true;
 }
 
@@ -2414,7 +2425,8 @@ bool Encode(const uint8_t* rgb, int width, int height, int stride,
   if (width <= 0 || height <= 0 || std::abs(stride) < 3 * width) return false;
 
   Encoder* const enc = EncoderFactory(rgb, width, height, stride,
-                                      param.yuv_mode, sink);
+                                      param.yuv_mode, sink, kRGBInput,
+                                      param.memory);
   return FinishEncoding(enc, param);
 }
 
@@ -2449,8 +2461,8 @@ bool EncodeBGRA(const uint8_t* bgra, int width, int height, int stride,
     }
     return Encode(rgb.get(), width, height, rgb_stride, param, sink);
   }
-  Encoder* const enc =
-      EncoderFactory(bgra, width, height, stride, mode, sink, kBGRAInput);
+  Encoder* const enc = EncoderFactory(bgra, width, height, stride, mode, sink,
+                                      kBGRAInput, param.memory);
   return FinishEncoding(enc, param);
 }
 
@@ -2476,8 +2488,8 @@ bool EncodeRGBA(const uint8_t* rgba, int width, int height, int stride,
     }
     return Encode(rgb.get(), width, height, rgb_stride, param, sink);
   }
-  Encoder* const enc =
-      EncoderFactory(rgba, width, height, stride, mode, sink, kRGBAInput);
+  Encoder* const enc = EncoderFactory(rgba, width, height, stride, mode, sink,
+                                      kRGBAInput, param.memory);
   return FinishEncoding(enc, param);
 }
 
@@ -2486,8 +2498,9 @@ bool EncodeGray(const uint8_t* gray, int width, int height, int stride,
   if (gray == nullptr || sink == nullptr) return false;
   if (width <= 0 || height <= 0 || std::abs(stride) < width) return false;
 
-  Encoder* const enc =
-      new (std::nothrow) Encoder400G(width, height, gray, stride, sink);
+  Encoder* const enc = new (std::nothrow) Encoder400G(width, height, gray,
+                                                      stride, sink,
+                                                      param.memory);
   return FinishEncoding(enc, param);
 }
 

--- a/src/jpeg_tools.cc
+++ b/src/jpeg_tools.cc
@@ -183,6 +183,9 @@ SjpegYUVMode SjpegRiskiness(const uint8_t* rgb,
   const int s = sjpeg::kRGBSize;  // shortcut
   const int kRGB3 = s * s * s;
   const int gray = (s / 2) * (1 + s) * s;   // gray level for y=0,u=128,v=128
+  // idx packs y + s * (u + s * v), so the samples with neutral chroma are
+  // exactly the ones in [gray_min, gray_min + s), whatever their luma.
+  const int gray_min = gray - gray % s;
 
   cvrt_func(rgb, width, &row2[0]);  // convert first row ahead
   for (int j = 1; j < height; ++j) {
@@ -200,11 +203,13 @@ SjpegYUVMode SjpegRiskiness(const uint8_t* rgb,
         total_score += score;
         count += 1.0;
       }
-      gray_count += (std::abs(idx0 - gray) < s);
+      gray_count += (idx0 >= gray_min && idx0 < gray_min + s);
     }
   }
   if (count > 0) total_score /= count;
-  gray_count /= (width * height);
+  // the loops above visit (width - 1) x (height - 1) samples
+  const double num_samples = (width - 1.) * (height - 1.);
+  if (num_samples > 0.) gray_count /= num_samples;
 
   // number of pixels evaluated
   const double frac = 100. * count / (width * height);

--- a/src/jpeg_tools.cc
+++ b/src/jpeg_tools.cc
@@ -31,16 +31,17 @@ namespace {
 // the passed JPEG buffer. It assumes the streams starts wih an SOI marker,
 // like any valid JPEG should. Returned value points to the beginning of the
 // marker and is guarantied to contain a least 8 bytes of valid data.
-const uint8_t* GetSOFData(const uint8_t* src, int size) {
-  if (src == nullptr) return nullptr;
-  const uint8_t* const end = src + size - 8;   // 8 bytes of safety, for marker
-  src += 2;   // skip M_SOI
-  for (; src < end && *src != 0xff; ++src) { /* search first 0xff marker */ }
-  while (src < end) {
-    const uint32_t marker = static_cast<uint32_t>((src[0] << 8) | src[1]);
-    if (marker == M_SOF0 || marker == M_SOF1) return src;
-    const size_t s = 2 + ((src[2] << 8) | src[3]);
-    src += s;
+// Positions are used instead of pointers, to never build one past the end.
+const uint8_t* GetSOFData(const uint8_t* src, size_t size) {
+  if (src == nullptr || size < 2 + 8) return nullptr;
+  const size_t end = size - 8;   // 8 bytes of safety, for the marker
+  size_t pos = 2;   // skip M_SOI
+  while (pos < end && src[pos] != 0xff) { ++pos; }  // search first 0xff marker
+  while (pos < end) {
+    const uint32_t marker =
+        static_cast<uint32_t>((src[pos] << 8) | src[pos + 1]);
+    if (marker == M_SOF0 || marker == M_SOF1) return src + pos;
+    pos += 2 + ((src[pos + 2] << 8) | src[pos + 3]);
   }
   return nullptr;  // No SOF marker found
 }
@@ -48,10 +49,10 @@ const uint8_t* GetSOFData(const uint8_t* src, int size) {
 
 bool SjpegDimensions(const uint8_t* src0, size_t size,
                      int* width, int* height, int* is_yuv420) {
-  if (width == nullptr || height == nullptr) return false;
-  const uint8_t* src = GetSOFData(src0, size);
-  const size_t left_over = size - (src - src0);
-  if (src == nullptr || left_over < 8 + 3 * 1) return false;
+  const uint8_t* const src = GetSOFData(src0, size);
+  if (src == nullptr) return false;
+  const size_t left_over = size - static_cast<size_t>(src - src0);
+  if (left_over < 8 + 3 * 1) return false;
   if (height != nullptr) *height = (src[5] << 8) | src[6];
   if (width != nullptr) *width = (src[7] << 8) | src[8];
   if (is_yuv420 != nullptr) {

--- a/src/jpeg_tools.cc
+++ b/src/jpeg_tools.cc
@@ -245,7 +245,7 @@ int YUVToRiskIdx(int16_t y, int16_t u, int16_t v) {
 
 // return riskiness score on an 8x8 block. Input is YUV444 block
 // of DCT coefficients (Y/U/V).
-double DCTRiskinessScore(const int16_t yuv[3 * 8], int16_t scores[8 * 8]) {
+double DCTRiskinessScore(const int16_t yuv[3 * 64], int16_t scores[8 * 8]) {
   uint16_t idx[64];
   for (int k = 0; k < 64; ++k) {
     idx[k] = YUVToRiskIdx(yuv[k + 0 * 64], yuv[k + 1 * 64],  yuv[k + 2 * 64]);

--- a/src/jpeg_tools.cc
+++ b/src/jpeg_tools.cc
@@ -19,6 +19,7 @@
 #include <string.h>   // for memset
 
 #include <cstdlib>
+#include <utility>   // for std::swap
 #include <vector>
 
 #include "sjpegi.h"
@@ -212,7 +213,7 @@ SjpegYUVMode SjpegRiskiness(const uint8_t* rgb,
   if (num_samples > 0.) gray_count /= num_samples;
 
   // number of pixels evaluated
-  const double frac = 100. * count / (width * height);
+  const double frac = 100. * count / ((double)width * height);
   // if less than 1% of pixels were evaluated -> below noise level.
   if (frac < 1.) total_score = 0.;
 

--- a/src/md5sum.h
+++ b/src/md5sum.h
@@ -19,6 +19,7 @@
 #ifndef SJPEG_MD5SUM_H_
 #define SJPEG_MD5SUM_H_
 
+#include <cassert>
 #include <cstdint>
 #include <cstdio>
 #include <string>

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -209,7 +209,10 @@ struct Histo {
 
 struct Encoder {
  public:
-  Encoder(SjpegYUVMode yuv_mode, int W, int H, ByteSink* sink);
+  // 'memory' can be null (default manager). It is passed at construction,
+  // and not later, because sub-classes can allocate in their constructor.
+  Encoder(SjpegYUVMode yuv_mode, int W, int H, ByteSink* sink,
+          MemoryManager* memory);
   virtual ~Encoder();
   bool Ok() const { return ok_; }
 

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -69,6 +69,9 @@ extern bool SupportsNEON();
 #define M_SOS   0xffda
 #define M_DQT   0xffdb
 
+// Maximum picture dimension: SOF stores the width and height on 16 bits.
+enum { kMaxDimension = 0xffff };
+
 // Forward 8x8 Fourier transforms, in-place.
 typedef void (*FdctFunc)(int16_t *coeffs, int num_blocks);
 FdctFunc GetFdct();

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -85,7 +85,7 @@ extern const int kRGBSize;
 extern const uint8_t kSharpnessScore[];
 
 // internal riskiness scoring functions:
-extern double DCTRiskinessScore(const int16_t yuv[3 * 8],
+extern double DCTRiskinessScore(const int16_t yuv[3 * 64],
                                 int16_t scores[8 * 8]);
 extern double BlockRiskinessScore(const uint8_t* rgb, int stride,
                                   int16_t scores[8 * 8]);
@@ -321,7 +321,7 @@ struct Encoder {
   float ComputePSNR() const;
 
  protected:
-  bool SetError();   // sets ok_ to true
+  bool SetError();   // sets ok_ to false, and returns false
 
   // format-specific parameters, set by virtual InitComponents()
   const SjpegYUVMode yuv_mode_;   // 444, 420 or 400 only

--- a/src/yuv_convert.cc
+++ b/src/yuv_convert.cc
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <memory>
+#include <mutex>  // NOLINT
 #include <vector>
 using std::vector;
 
@@ -111,9 +112,9 @@ static uint32_t kLinearToGammaTab[GAMMA_TABLE_SIZE + 2];
 static uint32_t kGammaToLinearTab[MAX_Y_T + 1];   // size scales with Y_FIX
 
 static void InitGammaTablesF() {
-  static bool done = false;
+  static std::once_flag once;
   assert(2 * GAMMA_TO_LINEAR_BITS < 32);  // we use uint32_t intermediate values
-  if (!done) {
+  std::call_once(once, []() {
     int v;
     const double norm = 1. / MAX_Y_T;
     const double scale = 1. / GAMMA_TABLE_SIZE;
@@ -148,8 +149,7 @@ static void InitGammaTablesF() {
     // to prevent small rounding errors to cause read-overflow:
     kLinearToGammaTab[GAMMA_TABLE_SIZE + 1] =
         kLinearToGammaTab[GAMMA_TABLE_SIZE];
-    done = true;
-  }
+  });
 }
 
 // return value has a fixed-point precision of GAMMA_TO_LINEAR_BITS
@@ -408,8 +408,8 @@ static void (*kSharpFilterRow)(const int16_t* A, const int16_t* B,
                                int len, const uint16_t* best_y, uint16_t* out);
 
 static void InitFunctionPointers() {
-  static bool done = false;
-  if (!done) {
+  static std::once_flag once;
+  std::call_once(once, []() {
     kSharpUpdateY = SharpUpdateY_C;
     kSharpUpdateRGB = SharpUpdateRGB_C;
     kSharpFilterRow = SharpFilterRow_C;
@@ -427,8 +427,7 @@ static void InitFunctionPointers() {
       kSharpFilterRow = SharpFilterRow_NEON;
     }
 #endif
-    done = true;
-  }
+  });
 }
 
 //------------------------------------------------------------------------------

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -485,6 +485,26 @@ TEST(SinkFailure) {
   CHECK(seen_success);
 }
 
+TEST(CompressionMethod) {
+  const int kWidth = 48, kHeight = 32;
+  const std::vector<uint8_t> rgb = MakeRGB(kWidth, kHeight);
+  std::string out[11];
+  for (int method = -1; method <= 9; ++method) {
+    uint8_t* data = nullptr;
+    const size_t size = SjpegEncode(&rgb[0], kWidth, kHeight, 3 * kWidth,
+                                    &data, 76.f, method, SJPEG_YUV_420);
+    CHECK(size > 0 && data != nullptr);
+    if (data != nullptr) {
+      out[method + 1].assign(reinterpret_cast<const char*>(data), size);
+      CHECK(HasSize(out[method + 1], kWidth, kHeight));
+    }
+    SjpegFreeBuffer(data);
+  }
+  // methods outside of [0..8] are clamped to the nearest valid one
+  CHECK(out[0] == out[1]);     // -1 -> 0
+  CHECK(out[10] == out[9]);    //  9 -> 8
+}
+
 TEST(QuantMatrix) {
   for (int quality = 0; quality <= 100; quality += 5) {
     for (int chroma = 0; chroma <= 1; ++chroma) {

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -15,11 +15,13 @@
 //  Unit tests for the library's API. Usage:
 //     ./unit_test [test-name]...
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <string>
+#include <thread>  // NOLINT
 #include <vector>
 
 #include "sjpeg.h"
@@ -93,7 +95,7 @@ std::vector<uint8_t> MakeRGB(int width, int height) {
 // Encodes a whole picture, with the packed stride.
 template<class T> bool EncodeRGB(const std::vector<uint8_t>& rgb, int W, int H,
                                  const sjpeg::EncoderParam& param, T* out) {
-  return sjpeg::Encode(&rgb[0], W, H, 3 * W, param, out);
+  return sjpeg::Encode(rgb.data(), W, H, 3 * W, param, out);
 }
 
 // True if the bitstream announces the expected dimensions.
@@ -105,11 +107,33 @@ bool HasSize(const std::string& jpg, int W, int H) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// The sharp-YUV tables are built lazily: concurrent encoders must not race on
+// them, nor see one half-filled. Runs first, since they are only initialized
+// once per process and any earlier test would have done it already.
+TEST(Threads) {
+  const int W = 33, H = 21, kNumThreads = 8;
+  const std::vector<uint8_t> rgb = MakeRGB(W, H);
+  std::vector<std::string> out(kNumThreads);
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kNumThreads; ++t) {
+    threads.push_back(std::thread([&, t]() {
+      sjpeg::EncoderParam param(72.f);
+      param.yuv_mode = SJPEG_YUV_SHARP;
+      sjpeg::Encode(rgb.data(), W, H, 3 * W, param, &out[t]);
+    }));
+  }
+  for (size_t t = 0; t < threads.size(); ++t) threads[t].join();
+  // same input, same parameters: the bitstreams must all be identical
+  for (int t = 0; t < kNumThreads; ++t) {
+    CHECK(!out[t].empty() && out[t] == out[0]);
+  }
+}
+
 TEST(Compress) {
   const int kWidth = 61, kHeight = 37;
   const std::vector<uint8_t> rgb = MakeRGB(kWidth, kHeight);
   std::string out;
-  CHECK(SjpegCompress(&rgb[0], kWidth, kHeight, 75.f, &out));
+  CHECK(SjpegCompress(rgb.data(), kWidth, kHeight, 75.f, &out));
   CHECK(out.size() > 0);
   int width = 0, height = 0, is_yuv420 = -1;
   CHECK(SjpegDimensions(out, &width, &height, &is_yuv420));
@@ -146,15 +170,16 @@ TEST(InvalidArguments) {
     return SjpegEncode(src, W, H, stride, dst, 75.f, 4, mode);
   };
   CHECK(enc(nullptr, kWidth, kHeight, 3 * kWidth, &data, SJPEG_YUV_420) == 0);
-  CHECK(enc(&rgb[0], kWidth, kHeight, 3 * kWidth, nullptr, SJPEG_YUV_420) == 0);
-  CHECK(enc(&rgb[0], 0, kHeight, 3 * kWidth, &data, SJPEG_YUV_420) == 0);
-  CHECK(enc(&rgb[0], kWidth, -1, 3 * kWidth, &data, SJPEG_YUV_420) == 0);
-  CHECK(enc(&rgb[0], kWidth, kHeight, 3 * kWidth - 1, &data,
+  CHECK(enc(rgb.data(), kWidth, kHeight, 3 * kWidth, nullptr,
+            SJPEG_YUV_420) == 0);
+  CHECK(enc(rgb.data(), 0, kHeight, 3 * kWidth, &data, SJPEG_YUV_420) == 0);
+  CHECK(enc(rgb.data(), kWidth, -1, 3 * kWidth, &data, SJPEG_YUV_420) == 0);
+  CHECK(enc(rgb.data(), kWidth, kHeight, 3 * kWidth - 1, &data,
             SJPEG_YUV_420) == 0);
 
   // unknown yuv_mode: no encoder can be created for it. 7 is the largest
   // value the enum can hold without being out of range.
-  CHECK(enc(&rgb[0], kWidth, kHeight, 3 * kWidth,
+  CHECK(enc(rgb.data(), kWidth, kHeight, 3 * kWidth,
             &data, static_cast<SjpegYUVMode>(7)) == 0);
   CHECK(data == nullptr);
   const sjpeg::EncoderParam param;
@@ -194,10 +219,9 @@ typedef bool (*EncodeYUVFunc)(const uint8_t*, int, const uint8_t*, int,
 // The padding bytes of the U/V planes must never reach the output, whatever
 // the strides are. Dimensions are picked so that the last MCU row/column is
 // clipped, since that's where the samples are replicated.
-void CheckStrides(EncodeYUVFunc encode, int sub) {
-  const int kWidth = 20, kHeight = 20;
-  const int uv_w = (kWidth + sub - 1) / sub, uv_h = (kHeight + sub - 1) / sub;
-  const std::vector<uint8_t> Y = MakePlane(kWidth, kHeight, 20);
+void CheckStrides(EncodeYUVFunc encode, int sub, int width, int height) {
+  const int uv_w = (width + sub - 1) / sub, uv_h = (height + sub - 1) / sub;
+  const std::vector<uint8_t> Y = MakePlane(width, height, 20);
   const std::vector<uint8_t> U = MakePlane(uv_w, uv_h, 60);
   const std::vector<uint8_t> V = MakePlane(uv_w, uv_h, 140);
   const sjpeg::EncoderParam param(80.f);
@@ -208,16 +232,24 @@ void CheckStrides(EncodeYUVFunc encode, int sub) {
       const std::vector<uint8_t> u = WithStride(U, uv_w, uv_h, u_stride);
       const std::vector<uint8_t> v = WithStride(V, uv_w, uv_h, v_stride);
       std::string out;
-      CHECK(encode(&Y[0], kWidth, &u[0], u_stride, &v[0], v_stride,
-                   kWidth, kHeight, param, sjpeg::MakeByteSink(&out).get()));
+      CHECK(encode(Y.data(), width, u.data(), u_stride, v.data(), v_stride,
+                   width, height, param, sjpeg::MakeByteSink(&out).get()));
       if (ref.empty()) ref = out;
       CHECK(!out.empty() && out == ref);
     }
   }
 }
 
-TEST(EncodeYUV420Strides) { CheckStrides(&sjpeg::EncodeYUV420, 2); }
-TEST(EncodeYUV444Strides) { CheckStrides(&sjpeg::EncodeYUV444, 1); }
+// 17x13 is odd in both directions: the chroma planes have a half sample in
+// the last row and column, on top of the clipped MCU.
+TEST(EncodeYUV420Strides) {
+  CheckStrides(&sjpeg::EncodeYUV420, 2, 20, 20);
+  CheckStrides(&sjpeg::EncodeYUV420, 2, 17, 13);
+}
+TEST(EncodeYUV444Strides) {
+  CheckStrides(&sjpeg::EncodeYUV444, 1, 20, 20);
+  CheckStrides(&sjpeg::EncodeYUV444, 1, 17, 13);
+}
 
 TEST(EncodeNV) {
   const int kWidth = 18, kHeight = 14;
@@ -226,10 +258,12 @@ TEST(EncodeNV) {
   const std::vector<uint8_t> UV = MakePlane(uv_stride, uv_h, 90);
   const sjpeg::EncoderParam param(75.f);
   std::string out12, out21;
-  CHECK(sjpeg::EncodeNV12(&Y[0], kWidth, &UV[0], uv_stride, kWidth, kHeight,
-                          param, sjpeg::MakeByteSink(&out12).get()));
-  CHECK(sjpeg::EncodeNV21(&Y[0], kWidth, &UV[0], uv_stride, kWidth, kHeight,
-                          param, sjpeg::MakeByteSink(&out21).get()));
+  CHECK(sjpeg::EncodeNV12(Y.data(), kWidth, UV.data(), uv_stride,
+                          kWidth, kHeight, param,
+                          sjpeg::MakeByteSink(&out12).get()));
+  CHECK(sjpeg::EncodeNV21(Y.data(), kWidth, UV.data(), uv_stride,
+                          kWidth, kHeight, param,
+                          sjpeg::MakeByteSink(&out21).get()));
   CHECK(HasSize(out12, kWidth, kHeight));
   CHECK(out12 != out21);   // U and V are swapped
 
@@ -241,14 +275,69 @@ TEST(EncodeNV) {
                         int uv_step, int W, int H, sjpeg::ByteSink* s) {
     return sjpeg::EncodeNV12(y, y_step, uv, uv_step, W, H, param, s);
   };
-  CHECK(!nv12(&Y[0], kWidth, &UV[0], uv_stride, kWidth, kHeight, nullptr));
-  CHECK(!nv12(nullptr, kWidth, &UV[0], uv_stride, kWidth, kHeight, sink));
-  CHECK(!nv12(&Y[0], kWidth, nullptr, uv_stride, kWidth, kHeight, sink));
-  CHECK(!nv12(&Y[0], kWidth, &UV[0], uv_stride, 0, kHeight, sink));
-  CHECK(!nv12(&Y[0], kWidth - 1, &UV[0], uv_stride, kWidth, kHeight, sink));
-  CHECK(!nv12(&Y[0], kWidth, &UV[0], uv_stride - 1, kWidth, kHeight, sink));
-  CHECK(!sjpeg::EncodeNV21(&Y[0], kWidth, &UV[0], uv_stride, kWidth, kHeight,
-                           param, nullptr));
+  CHECK(!nv12(Y.data(), kWidth, UV.data(), uv_stride,
+              kWidth, kHeight, nullptr));
+  CHECK(!nv12(nullptr, kWidth, UV.data(), uv_stride, kWidth, kHeight, sink));
+  CHECK(!nv12(Y.data(), kWidth, nullptr, uv_stride, kWidth, kHeight, sink));
+  CHECK(!nv12(Y.data(), kWidth, UV.data(), uv_stride, 0, kHeight, sink));
+  CHECK(!nv12(Y.data(), kWidth - 1, UV.data(), uv_stride,
+              kWidth, kHeight, sink));
+  CHECK(!nv12(Y.data(), kWidth, UV.data(), uv_stride - 1,
+              kWidth, kHeight, sink));
+  CHECK(!sjpeg::EncodeNV21(Y.data(), kWidth, UV.data(), uv_stride,
+                           kWidth, kHeight, param, nullptr));
+}
+
+// Vertically flips 'height' rows of 'row_size' bytes.
+std::vector<uint8_t> Flip(const std::vector<uint8_t>& src, int row_size,
+                          int height) {
+  std::vector<uint8_t> dst(src.size());
+  for (int y = 0; y < height; ++y) {
+    memcpy(&dst[static_cast<size_t>(y) * row_size],
+           &src[static_cast<size_t>(height - 1 - y) * row_size], row_size);
+  }
+  return dst;
+}
+
+// Last row of 'p', to be paired with a negative stride.
+const uint8_t* Last(const std::vector<uint8_t>& p, int row_size, int height) {
+  return p.data() + static_cast<size_t>(height - 1) * row_size;
+}
+
+// Only |stride| is validated: a negative stride is legal, and describes a
+// bottom-up buffer. It must encode exactly like the flipped picture does with
+// a positive one. 17x13 is odd both ways, so the last MCU clips too.
+TEST(NegativeStrides) {
+  const int W = 17, H = 13, uv_w = (W + 1) / 2, uv_h = (H + 1) / 2;
+  const int uv_stride = 2 * uv_w;
+  const sjpeg::EncoderParam p(78.f);
+  const std::vector<uint8_t> rgb = MakeRGB(W, H), Y = MakePlane(W, H, 20);
+  const std::vector<uint8_t> U = MakePlane(uv_w, uv_h, 60);
+  const std::vector<uint8_t> V = MakePlane(uv_w, uv_h, 140);
+  const std::vector<uint8_t> UV = MakePlane(uv_stride, uv_h, 90);
+  std::string a, b;
+  const auto match = [&a, &b]() { CHECK(!a.empty() && a == b);
+                                  a.clear();
+                                  b.clear(); };
+  CHECK(EncodeRGB(Flip(rgb, 3 * W, H), W, H, p, &a));
+  CHECK(sjpeg::Encode(Last(rgb, 3 * W, H), W, H, -3 * W, p, &b));
+  match();
+
+  CHECK(sjpeg::EncodeYUV420(Flip(Y, W, H).data(), W,
+                            Flip(U, uv_w, uv_h).data(), uv_w,
+                            Flip(V, uv_w, uv_h).data(), uv_w, W, H, p,
+                            sjpeg::MakeByteSink(&a).get()));
+  CHECK(sjpeg::EncodeYUV420(Last(Y, W, H), -W, Last(U, uv_w, uv_h), -uv_w,
+                            Last(V, uv_w, uv_h), -uv_w, W, H, p,
+                            sjpeg::MakeByteSink(&b).get()));
+  match();
+
+  CHECK(sjpeg::EncodeNV12(Flip(Y, W, H).data(), W,
+                          Flip(UV, uv_stride, uv_h).data(), uv_stride, W, H, p,
+                          sjpeg::MakeByteSink(&a).get()));
+  CHECK(sjpeg::EncodeNV12(Last(Y, W, H), -W, Last(UV, uv_stride, uv_h),
+                          -uv_stride, W, H, p, sjpeg::MakeByteSink(&b).get()));
+  match();
 }
 
 // Records every block it hands out, and refuses to release a pointer that
@@ -310,11 +399,11 @@ TEST(LargeDimensions) {
   CHECK(HasSize(out, kMaxDim, kSmallDim));
   CHECK(!EncodeRGB(rgb, kMaxDim + 1, kSmallDim, param, &out));
   CHECK(!EncodeRGB(rgb, kSmallDim, kMaxDim + 1, param, &out));
-  CHECK(!sjpeg::EncodeGray(&rgb[0], kMaxDim + 1, kSmallDim, kMaxDim + 1,
+  CHECK(!sjpeg::EncodeGray(rgb.data(), kMaxDim + 1, kSmallDim, kMaxDim + 1,
                            param, &out));
   uint8_t* data = nullptr;
-  CHECK(SjpegEncode(&rgb[0], kMaxDim + 1, kSmallDim, 3 * (kMaxDim + 1), &data,
-                    50.f, 4, SJPEG_YUV_420) == 0);
+  CHECK(SjpegEncode(rgb.data(), kMaxDim + 1, kSmallDim, 3 * (kMaxDim + 1),
+                    &data, 50.f, 4, SJPEG_YUV_420) == 0);
   CHECK(data == nullptr);
 }
 
@@ -367,7 +456,7 @@ TEST(Dimensions) {
   const int kWidth = 35, kHeight = 19;
   const std::vector<uint8_t> rgb = MakeRGB(kWidth, kHeight);
   std::string jpg;
-  CHECK(SjpegCompress(&rgb[0], kWidth, kHeight, 60.f, &jpg));
+  CHECK(SjpegCompress(rgb.data(), kWidth, kHeight, 60.f, &jpg));
   const uint8_t* const data = reinterpret_cast<const uint8_t*>(jpg.data());
   const size_t size = jpg.size();
 
@@ -409,14 +498,14 @@ TEST(Riskiness) {
     // a gray picture is detected as such, whatever its dimensions
     const std::vector<uint8_t> gray = MakeFlatRGB(size, size, 128, 128, 128);
     float risk = -1.f;
-    CHECK(SjpegRiskiness(&gray[0], size, size, 3 * size, &risk)
+    CHECK(SjpegRiskiness(gray.data(), size, size, 3 * size, &risk)
               == SJPEG_YUV_400);
     CHECK(risk >= 0.f && risk <= 100.f);
 
     // A flat but tinted picture is not gray either, even though its packed
     // y/u/v index sits close to the one of the gray level.
     const std::vector<uint8_t> tint = MakeFlatRGB(size, size, 140, 120, 90);
-    CHECK(SjpegRiskiness(&tint[0], size, size, 3 * size, nullptr)
+    CHECK(SjpegRiskiness(tint.data(), size, size, 3 * size, nullptr)
               != SJPEG_YUV_400);
 
     // and neither is a colored one
@@ -429,7 +518,7 @@ TEST(Riskiness) {
         p[2] = ((x ^ y) & 8) ? 20 : 220;
       }
     }
-    CHECK(SjpegRiskiness(&color[0], size, size, 3 * size, nullptr)
+    CHECK(SjpegRiskiness(color.data(), size, size, 3 * size, nullptr)
               != SJPEG_YUV_400);
   }
   // end to end: YUV_AUTO on a gray picture emits a single quantization matrix
@@ -441,6 +530,33 @@ TEST(Riskiness) {
   CHECK(EncodeRGB(gray, kWidth, kHeight, param, &out));
   uint8_t quant[2][64];
   CHECK(SjpegFindQuantizer(out, quant) == 1);
+}
+
+// TARGET_SIZE converges by comparing ComputeSize(), which adds HeaderSize(),
+// against the requested value. SJPEG_YUV_400 writes a single quantization
+// matrix where the other modes write two: charging it for both (67 bytes)
+// makes the search settle on the wrong quality. SJPEG_YUV_420 is the control.
+TEST(TargetSize) {
+  const int W = 96, H = 64;
+  const std::vector<uint8_t> rgb = MakeRGB(W, H);
+  const SjpegYUVMode kModes[] = { SJPEG_YUV_400, SJPEG_YUV_420 };
+  for (size_t m = 0; m < ARRAY_SIZE(kModes); ++m) {
+    // a plain encode gives a size that the search is sure to be able to reach
+    sjpeg::EncoderParam param(60.f);
+    param.yuv_mode = kModes[m];
+    std::string out;
+    CHECK(EncodeRGB(rgb, W, H, param, &out));
+    const double target = out.size();
+
+    param.target_mode = sjpeg::EncoderParam::TARGET_SIZE;
+    param.target_value = static_cast<float>(target);
+    param.tolerance = 1.f;   // percent
+    param.passes = 12;
+    CHECK(EncodeRGB(rgb, W, H, param, &out));
+    // The search stops on |dq| rather than on the size, so it only lands
+    // close by. One quantization matrix too many costs several percent.
+    CHECK(fabs(out.size() - target) < 0.03 * target);
+  }
 }
 
 // Behaves like a memory sink, but starts refusing to commit after a while.
@@ -491,7 +607,7 @@ TEST(CompressionMethod) {
   std::string out[11];
   for (int method = -1; method <= 9; ++method) {
     uint8_t* data = nullptr;
-    const size_t size = SjpegEncode(&rgb[0], kWidth, kHeight, 3 * kWidth,
+    const size_t size = SjpegEncode(rgb.data(), kWidth, kHeight, 3 * kWidth,
                                     &data, 76.f, method, SJPEG_YUV_420);
     CHECK(size > 0 && data != nullptr);
     if (data != nullptr) {

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -151,6 +151,12 @@ TEST(InvalidArguments) {
   CHECK(enc(&rgb[0], kWidth, -1, 3 * kWidth, &data, SJPEG_YUV_420) == 0);
   CHECK(enc(&rgb[0], kWidth, kHeight, 3 * kWidth - 1, &data,
             SJPEG_YUV_420) == 0);
+
+  // unknown yuv_mode: no encoder can be created for it. 7 is the largest
+  // value the enum can hold without being out of range.
+  CHECK(enc(&rgb[0], kWidth, kHeight, 3 * kWidth,
+            &data, static_cast<SjpegYUVMode>(7)) == 0);
+  CHECK(data == nullptr);
   const sjpeg::EncoderParam param;
   std::string out;
   CHECK(!sjpeg::Encode(nullptr, kWidth, kHeight, 3 * kWidth, param, &out));

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -393,6 +393,56 @@ TEST(Dimensions) {
   }
 }
 
+// Flat picture of the given color.
+std::vector<uint8_t> MakeFlatRGB(int width, int height, int r, int g, int b) {
+  const uint8_t color[3] = { static_cast<uint8_t>(r), static_cast<uint8_t>(g),
+                             static_cast<uint8_t>(b) };
+  std::vector<uint8_t> rgb(3 * static_cast<size_t>(width) * height);
+  for (size_t i = 0; i < rgb.size(); ++i) rgb[i] = color[i % 3];
+  return rgb;
+}
+
+TEST(Riskiness) {
+  const int kSizes[] = { 8, 16, 32, 64, 128, 400 };
+  for (size_t s = 0; s < ARRAY_SIZE(kSizes); ++s) {
+    const int size = kSizes[s];
+    // a gray picture is detected as such, whatever its dimensions
+    const std::vector<uint8_t> gray = MakeFlatRGB(size, size, 128, 128, 128);
+    float risk = -1.f;
+    CHECK(SjpegRiskiness(&gray[0], size, size, 3 * size, &risk)
+              == SJPEG_YUV_400);
+    CHECK(risk >= 0.f && risk <= 100.f);
+
+    // A flat but tinted picture is not gray either, even though its packed
+    // y/u/v index sits close to the one of the gray level.
+    const std::vector<uint8_t> tint = MakeFlatRGB(size, size, 140, 120, 90);
+    CHECK(SjpegRiskiness(&tint[0], size, size, 3 * size, nullptr)
+              != SJPEG_YUV_400);
+
+    // and neither is a colored one
+    std::vector<uint8_t> color(3 * static_cast<size_t>(size) * size);
+    for (int y = 0; y < size; ++y) {
+      for (int x = 0; x < size; ++x) {
+        uint8_t* const p = &color[3 * (x + static_cast<size_t>(y) * size)];
+        p[0] = ((x ^ y) & 8) ? 220 : 20;
+        p[1] = 40;
+        p[2] = ((x ^ y) & 8) ? 20 : 220;
+      }
+    }
+    CHECK(SjpegRiskiness(&color[0], size, size, 3 * size, nullptr)
+              != SJPEG_YUV_400);
+  }
+  // end to end: YUV_AUTO on a gray picture emits a single quantization matrix
+  const int kWidth = 40, kHeight = 24;
+  const std::vector<uint8_t> gray = MakeFlatRGB(kWidth, kHeight, 90, 90, 90);
+  sjpeg::EncoderParam param(75.f);
+  param.yuv_mode = SJPEG_YUV_AUTO;
+  std::string out;
+  CHECK(EncodeRGB(gray, kWidth, kHeight, param, &out));
+  uint8_t quant[2][64];
+  CHECK(SjpegFindQuantizer(out, quant) == 1);
+}
+
 TEST(QuantMatrix) {
   for (int quality = 0; quality <= 100; quality += 5) {
     for (int chroma = 0; chroma <= 1; ++chroma) {

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -318,6 +318,51 @@ TEST(LargeDimensions) {
   CHECK(data == nullptr);
 }
 
+// Refuses to allocate after the first 'num_ok' calls.
+class FailingMemory : public TrackingMemory {
+ public:
+  explicit FailingMemory(int num_ok) : num_ok_(num_ok) {}
+  virtual ~FailingMemory() {}
+  virtual void* Alloc(size_t size) {
+    if (num_ok_ <= 0) {
+      ++num_refused;
+      return nullptr;
+    }
+    --num_ok_;
+    return TrackingMemory::Alloc(size);
+  }
+  int num_refused = 0;
+
+ private:
+  int num_ok_;
+};
+
+// An allocation failure must be reported, whatever the stage it occurs at,
+// without crashing and without leaking.
+TEST(AllocationFailure) {
+  const int kWidth = 51, kHeight = 33;
+  const std::vector<uint8_t> rgb = MakeRGB(kWidth, kHeight);
+  const struct { sjpeg::EncoderParam::TargetMode mode; float value; } kTargets[]
+      = { { sjpeg::EncoderParam::TARGET_NONE, 0.f },
+          { sjpeg::EncoderParam::TARGET_SIZE, 2000.f },
+          { sjpeg::EncoderParam::TARGET_PSNR, 38.f } };
+  for (size_t t = 0; t < ARRAY_SIZE(kTargets); ++t) {
+    for (int num_ok = 0; num_ok < 8; ++num_ok) {
+      FailingMemory memory(num_ok);
+      sjpeg::EncoderParam param(80.f);
+      param.yuv_mode = SJPEG_YUV_420;
+      param.memory = &memory;
+      param.target_mode = kTargets[t].mode;
+      param.target_value = kTargets[t].value;
+      if (t > 0) param.passes = 5;
+      std::string out;
+      const bool ok = EncodeRGB(rgb, kWidth, kHeight, param, &out);
+      CHECK(ok == (memory.num_refused == 0));
+      CHECK(memory.live.empty());
+    }
+  }
+}
+
 TEST(QuantMatrix) {
   for (int quality = 0; quality <= 100; quality += 5) {
     for (int chroma = 0; chroma <= 1; ++chroma) {

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -363,6 +363,36 @@ TEST(AllocationFailure) {
   }
 }
 
+TEST(Dimensions) {
+  const int kWidth = 35, kHeight = 19;
+  const std::vector<uint8_t> rgb = MakeRGB(kWidth, kHeight);
+  std::string jpg;
+  CHECK(SjpegCompress(&rgb[0], kWidth, kHeight, 60.f, &jpg));
+  const uint8_t* const data = reinterpret_cast<const uint8_t*>(jpg.data());
+  const size_t size = jpg.size();
+
+  // all three pointers are optional
+  int width = 0, height = 0, is_yuv420 = -1;
+  CHECK(SjpegDimensions(jpg, &width, &height, &is_yuv420));
+  CHECK(width == kWidth && height == kHeight);
+  width = height = 0;
+  CHECK(SjpegDimensions(data, size, &width, nullptr, nullptr));
+  CHECK(width == kWidth);
+  CHECK(SjpegDimensions(data, size, nullptr, &height, nullptr));
+  CHECK(height == kHeight);
+  CHECK(SjpegDimensions(data, size, nullptr, nullptr, &is_yuv420));
+  CHECK(SjpegDimensions(data, size, nullptr, nullptr, nullptr));
+
+  // truncated or invalid input is rejected, and never read out of bounds
+  CHECK(!SjpegDimensions(nullptr, size, &width, &height, nullptr));
+  for (size_t n = 0; n <= size; ++n) {
+    int w = -1, h = -1, yuv420 = -1;
+    if (SjpegDimensions(data, n, &w, &h, &yuv420)) {
+      CHECK(w == kWidth && h == kHeight);   // never a partial answer
+    }
+  }
+}
+
 TEST(QuantMatrix) {
   for (int quality = 0; quality <= 100; quality += 5) {
     for (int chroma = 0; chroma <= 1; ++chroma) {

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -160,6 +160,59 @@ TEST(InvalidArguments) {
   CHECK(!sjpeg::EncodeGray(nullptr, kWidth, kHeight, kWidth, param, &out));
 }
 
+std::vector<uint8_t> MakePlane(int width, int height, int base) {
+  g_seed = kSeed;
+  std::vector<uint8_t> plane(static_cast<size_t>(width) * height);
+  for (size_t i = 0; i < plane.size(); ++i) {
+    plane[i] = static_cast<uint8_t>(base + (Random8b() >> 2));
+  }
+  return plane;
+}
+
+// Copies 'plane' into a buffer with the given stride, padding the extra bytes
+// with a value that must never show up in the output.
+std::vector<uint8_t> WithStride(const std::vector<uint8_t>& plane,
+                                int width, int height, int stride) {
+  std::vector<uint8_t> out(static_cast<size_t>(stride) * height, 0xd5);
+  for (int y = 0; y < height; ++y) {
+    memcpy(&out[static_cast<size_t>(y) * stride],
+           &plane[static_cast<size_t>(y) * width], width);
+  }
+  return out;
+}
+
+typedef bool (*EncodeYUVFunc)(const uint8_t*, int, const uint8_t*, int,
+                              const uint8_t*, int, int, int,
+                              const sjpeg::EncoderParam&, sjpeg::ByteSink*);
+
+// The padding bytes of the U/V planes must never reach the output, whatever
+// the strides are. Dimensions are picked so that the last MCU row/column is
+// clipped, since that's where the samples are replicated.
+void CheckStrides(EncodeYUVFunc encode, int sub) {
+  const int kWidth = 20, kHeight = 20;
+  const int uv_w = (kWidth + sub - 1) / sub, uv_h = (kHeight + sub - 1) / sub;
+  const std::vector<uint8_t> Y = MakePlane(kWidth, kHeight, 20);
+  const std::vector<uint8_t> U = MakePlane(uv_w, uv_h, 60);
+  const std::vector<uint8_t> V = MakePlane(uv_w, uv_h, 140);
+  const sjpeg::EncoderParam param(80.f);
+  std::string ref;
+  for (int u_pad = 0; u_pad <= 7; ++u_pad) {
+    for (int v_pad = 0; v_pad <= 7; v_pad += 7) {
+      const int u_stride = uv_w + u_pad, v_stride = uv_w + v_pad;
+      const std::vector<uint8_t> u = WithStride(U, uv_w, uv_h, u_stride);
+      const std::vector<uint8_t> v = WithStride(V, uv_w, uv_h, v_stride);
+      std::string out;
+      CHECK(encode(&Y[0], kWidth, &u[0], u_stride, &v[0], v_stride,
+                   kWidth, kHeight, param, sjpeg::MakeByteSink(&out).get()));
+      if (ref.empty()) ref = out;
+      CHECK(!out.empty() && out == ref);
+    }
+  }
+}
+
+TEST(EncodeYUV420Strides) { CheckStrides(&sjpeg::EncodeYUV420, 2); }
+TEST(EncodeYUV444Strides) { CheckStrides(&sjpeg::EncodeYUV444, 1); }
+
 TEST(QuantMatrix) {
   for (int quality = 0; quality <= 100; quality += 5) {
     for (int chroma = 0; chroma <= 1; ++chroma) {

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -1,0 +1,210 @@
+// Copyright 2026 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Unit tests for the library's API. Usage:
+//     ./unit_test [test-name]...
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <string>
+#include <vector>
+
+#include "sjpeg.h"
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+// Minimal test harness
+
+int g_num_checks = 0;
+int g_num_failures = 0;
+const char* g_test_name = "";
+
+bool CheckImpl(bool cond, const char* expr, int line) {
+  ++g_num_checks;
+  if (!cond) {
+    ++g_num_failures;
+    printf("  FAILED %s (line %d): %s\n", g_test_name, line, expr);
+  }
+  return cond;
+}
+#define CHECK(expr) CheckImpl(!!(expr), #expr, __LINE__)
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+
+struct TestCase { const char* name; void (*func)(); };
+
+std::vector<TestCase>& Tests() {
+  static std::vector<TestCase> tests;
+  return tests;
+}
+
+struct TestRegistrar {
+  TestRegistrar(const char* name, void (*func)()) {
+    const TestCase test = { name, func };
+    Tests().push_back(test);
+  }
+};
+
+#define TEST(Name)                                          \
+  void Test##Name();                                        \
+  const TestRegistrar kRegister##Name(#Name, &Test##Name);  \
+  void Test##Name()
+
+////////////////////////////////////////////////////////////////////////////////
+// Samples and shortcuts. The generators are deterministic, so that a failure
+// is always reproducible.
+
+const uint32_t kSeed = 7654321u;
+uint32_t g_seed = kSeed;
+
+uint8_t Random8b() {
+  g_seed = 1103515245u * g_seed + 12345u;
+  return static_cast<uint8_t>(g_seed >> 16);
+}
+
+// Noisy picture with some structure, hard to compress.
+std::vector<uint8_t> MakeRGB(int width, int height) {
+  g_seed = kSeed;
+  std::vector<uint8_t> rgb(3 * static_cast<size_t>(width) * height);
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      uint8_t* const p = &rgb[3 * (x + static_cast<size_t>(y) * width)];
+      p[0] = static_cast<uint8_t>(x * 5 + (Random8b() >> 3));
+      p[1] = static_cast<uint8_t>(y * 3 + (Random8b() >> 4));
+      p[2] = static_cast<uint8_t>(((x / 8) ^ (y / 8)) * 51);
+    }
+  }
+  return rgb;
+}
+
+// Encodes a whole picture, with the packed stride.
+template<class T> bool EncodeRGB(const std::vector<uint8_t>& rgb, int W, int H,
+                                 const sjpeg::EncoderParam& param, T* out) {
+  return sjpeg::Encode(&rgb[0], W, H, 3 * W, param, out);
+}
+
+// True if the bitstream announces the expected dimensions.
+bool HasSize(const std::string& jpg, int W, int H) {
+  int width = 0, height = 0;
+  return SjpegDimensions(jpg, &width, &height, nullptr) &&
+         width == W && height == H;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(Compress) {
+  const int kWidth = 61, kHeight = 37;
+  const std::vector<uint8_t> rgb = MakeRGB(kWidth, kHeight);
+  std::string out;
+  CHECK(SjpegCompress(&rgb[0], kWidth, kHeight, 75.f, &out));
+  CHECK(out.size() > 0);
+  int width = 0, height = 0, is_yuv420 = -1;
+  CHECK(SjpegDimensions(out, &width, &height, &is_yuv420));
+  CHECK(width == kWidth && height == kHeight);
+  CHECK(is_yuv420 == 0 || is_yuv420 == 1);
+}
+
+TEST(EncodeParams) {
+  const int kWidth = 32, kHeight = 16;
+  const std::vector<uint8_t> rgb = MakeRGB(kWidth, kHeight);
+  const SjpegYUVMode kModes[] = { SJPEG_YUV_AUTO, SJPEG_YUV_420,
+                                  SJPEG_YUV_SHARP, SJPEG_YUV_444,
+                                  SJPEG_YUV_400 };
+  for (size_t m = 0; m < ARRAY_SIZE(kModes); ++m) {
+    sjpeg::EncoderParam param(80.f);
+    param.yuv_mode = kModes[m];
+    std::string out;
+    CHECK(EncodeRGB(rgb, kWidth, kHeight, param, &out));
+    CHECK(HasSize(out, kWidth, kHeight));
+  }
+  // Higher quality must not compress better.
+  std::string small, large;
+  CHECK(EncodeRGB(rgb, kWidth, kHeight, sjpeg::EncoderParam(30.f), &small));
+  CHECK(EncodeRGB(rgb, kWidth, kHeight, sjpeg::EncoderParam(95.f), &large));
+  CHECK(small.size() < large.size());
+}
+
+TEST(InvalidArguments) {
+  const int kWidth = 16, kHeight = 16;
+  const std::vector<uint8_t> rgb = MakeRGB(kWidth, kHeight);
+  uint8_t* data = nullptr;
+  const auto enc = [](const uint8_t* src, int W, int H, int stride,
+                      uint8_t** dst, SjpegYUVMode mode) {
+    return SjpegEncode(src, W, H, stride, dst, 75.f, 4, mode);
+  };
+  CHECK(enc(nullptr, kWidth, kHeight, 3 * kWidth, &data, SJPEG_YUV_420) == 0);
+  CHECK(enc(&rgb[0], kWidth, kHeight, 3 * kWidth, nullptr, SJPEG_YUV_420) == 0);
+  CHECK(enc(&rgb[0], 0, kHeight, 3 * kWidth, &data, SJPEG_YUV_420) == 0);
+  CHECK(enc(&rgb[0], kWidth, -1, 3 * kWidth, &data, SJPEG_YUV_420) == 0);
+  CHECK(enc(&rgb[0], kWidth, kHeight, 3 * kWidth - 1, &data,
+            SJPEG_YUV_420) == 0);
+  const sjpeg::EncoderParam param;
+  std::string out;
+  CHECK(!sjpeg::Encode(nullptr, kWidth, kHeight, 3 * kWidth, param, &out));
+  CHECK(!EncodeRGB(rgb, kWidth, kHeight, param,
+                   static_cast<std::string*>(nullptr)));
+  CHECK(!EncodeRGB(rgb, kWidth, 0, param, &out));
+  CHECK(!sjpeg::EncodeGray(nullptr, kWidth, kHeight, kWidth, param, &out));
+}
+
+TEST(QuantMatrix) {
+  for (int quality = 0; quality <= 100; quality += 5) {
+    for (int chroma = 0; chroma <= 1; ++chroma) {
+      uint8_t matrix[64];
+      SjpegQuantMatrix(quality, chroma != 0, matrix);
+      for (size_t i = 0; i < 64; ++i) CHECK(matrix[i] >= 1);
+      const float estimate = SjpegEstimateQuality(matrix, chroma != 0);
+      CHECK(estimate >= quality - 1.f && estimate <= quality + 1.f);
+    }
+  }
+  // The matrices used for encoding must be recoverable from the bitstream.
+  const int kWidth = 24, kHeight = 24;
+  const std::vector<uint8_t> rgb = MakeRGB(kWidth, kHeight);
+  sjpeg::EncoderParam param(70.f);
+  param.adaptive_quantization = false;
+  std::string out;
+  CHECK(EncodeRGB(rgb, kWidth, kHeight, param, &out));
+  uint8_t quant[2][64];
+  CHECK(SjpegFindQuantizer(out, quant) == 2);
+  CHECK(memcmp(quant[0], param.GetQuantMatrix(0), 64) == 0);
+  CHECK(memcmp(quant[1], param.GetQuantMatrix(1), 64) == 0);
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  const std::vector<TestCase>& tests = Tests();
+  int num_run = 0;
+  for (size_t n = 0; n < tests.size(); ++n) {
+    // with arguments, only run the tests named on the command line
+    bool selected = (argc <= 1);
+    for (int c = 1; c < argc; ++c) selected |= !strcmp(argv[c], tests[n].name);
+    if (!selected) continue;
+    const int failures = g_num_failures;
+    g_test_name = tests[n].name;
+    tests[n].func();
+    ++num_run;
+    printf("%-4s %s\n", (g_num_failures == failures) ? "ok" : "FAIL",
+           tests[n].name);
+  }
+  printf("--\n%d test(s), %d check(s), %d failure(s)\n",
+         num_run, g_num_checks, g_num_failures);
+  if (num_run == 0) {
+    printf("no test was run!\n");
+    return 1;
+  }
+  return (g_num_failures == 0) ? 0 : 1;
+}

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -443,6 +443,48 @@ TEST(Riskiness) {
   CHECK(SjpegFindQuantizer(out, quant) == 1);
 }
 
+// Behaves like a memory sink, but starts refusing to commit after a while.
+class FailingSink : public sjpeg::ByteSink {
+ public:
+  explicit FailingSink(int num_ok) : num_ok_(num_ok) {}
+  virtual ~FailingSink() {}
+  virtual bool Commit(size_t used_size, size_t extra_size, uint8_t** data) {
+    pos_ += used_size;
+    if (num_ok_ <= 0) return false;
+    --num_ok_;
+    buf_.resize(pos_ + extra_size);
+    *data = extra_size ? &buf_[pos_] : nullptr;
+    return true;
+  }
+  virtual bool Finalize() { buf_.resize(pos_); return true; }
+  virtual void Reset() { buf_.clear(); pos_ = 0; }
+
+ private:
+  std::vector<uint8_t> buf_;
+  size_t pos_ = 0;
+  int num_ok_;
+};
+
+// A sink that stops accepting data must be reported, not crash. This is what
+// a file sink running out of space looks like.
+TEST(SinkFailure) {
+  const int kWidth = 32, kHeight = 32;
+  const std::vector<uint8_t> rgb = MakeRGB(kWidth, kHeight);
+  bool seen_failure = false, seen_success = false;
+  for (int num_ok = 0; num_ok < 64; ++num_ok) {
+    FailingSink sink(num_ok);
+    sjpeg::EncoderParam param(90.f);
+    param.yuv_mode = SJPEG_YUV_420;
+    if (EncodeRGB(rgb, kWidth, kHeight, param, &sink)) {
+      seen_success = true;
+    } else {
+      seen_failure = true;
+    }
+  }
+  CHECK(seen_failure);   // the test is only meaningful if both happened
+  CHECK(seen_success);
+}
+
 TEST(QuantMatrix) {
   for (int quality = 0; quality <= 100; quality += 5) {
     for (int chroma = 0; chroma <= 1; ++chroma) {

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -251,6 +251,53 @@ TEST(EncodeNV) {
                            param, nullptr));
 }
 
+// Records every block it hands out, and refuses to release a pointer that
+// doesn't come from it.
+class TrackingMemory : public sjpeg::MemoryManager {
+ public:
+  virtual ~TrackingMemory() {}
+  virtual void* Alloc(size_t size) {
+    void* const ptr = malloc(size);
+    if (ptr != nullptr) {
+      ++num_allocs;
+      live.push_back(ptr);
+    }
+    return ptr;
+  }
+  virtual void Free(void* const ptr) {
+    if (ptr == nullptr) return;
+    for (size_t i = 0; i < live.size(); ++i) {
+      if (live[i] == ptr) {
+        live.erase(live.begin() + i);
+        free(ptr);
+        return;
+      }
+    }
+    ++num_foreign_frees;   // not ours: releasing it would corrupt the heap
+  }
+  int num_allocs = 0;
+  int num_foreign_frees = 0;
+  std::vector<void*> live;
+};
+
+TEST(MemoryManager) {
+  const int kWidth = 40, kHeight = 24;
+  const std::vector<uint8_t> rgb = MakeRGB(kWidth, kHeight);
+  const SjpegYUVMode kModes[] = { SJPEG_YUV_420, SJPEG_YUV_SHARP,
+                                  SJPEG_YUV_444, SJPEG_YUV_400 };
+  for (size_t m = 0; m < ARRAY_SIZE(kModes); ++m) {
+    TrackingMemory memory;
+    sjpeg::EncoderParam param(75.f);
+    param.yuv_mode = kModes[m];
+    param.memory = &memory;
+    std::string out;
+    CHECK(EncodeRGB(rgb, kWidth, kHeight, param, &out));
+    CHECK(memory.num_allocs > 0);          // it was used at all
+    CHECK(memory.num_foreign_frees == 0);  // and used for every free()
+    CHECK(memory.live.empty());            // no leak
+  }
+}
+
 TEST(QuantMatrix) {
   for (int quality = 0; quality <= 100; quality += 5) {
     for (int chroma = 0; chroma <= 1; ++chroma) {

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -219,6 +219,38 @@ void CheckStrides(EncodeYUVFunc encode, int sub) {
 TEST(EncodeYUV420Strides) { CheckStrides(&sjpeg::EncodeYUV420, 2); }
 TEST(EncodeYUV444Strides) { CheckStrides(&sjpeg::EncodeYUV444, 1); }
 
+TEST(EncodeNV) {
+  const int kWidth = 18, kHeight = 14;
+  const int uv_h = (kHeight + 1) / 2, uv_stride = 2 * ((kWidth + 1) / 2);
+  const std::vector<uint8_t> Y = MakePlane(kWidth, kHeight, 30);
+  const std::vector<uint8_t> UV = MakePlane(uv_stride, uv_h, 90);
+  const sjpeg::EncoderParam param(75.f);
+  std::string out12, out21;
+  CHECK(sjpeg::EncodeNV12(&Y[0], kWidth, &UV[0], uv_stride, kWidth, kHeight,
+                          param, sjpeg::MakeByteSink(&out12).get()));
+  CHECK(sjpeg::EncodeNV21(&Y[0], kWidth, &UV[0], uv_stride, kWidth, kHeight,
+                          param, sjpeg::MakeByteSink(&out21).get()));
+  CHECK(HasSize(out12, kWidth, kHeight));
+  CHECK(out12 != out21);   // U and V are swapped
+
+  // one invalid argument at a time
+  std::string out;
+  const auto holder = sjpeg::MakeByteSink(&out);
+  sjpeg::ByteSink* const sink = holder.get();
+  const auto nv12 = [&](const uint8_t* y, int y_step, const uint8_t* uv,
+                        int uv_step, int W, int H, sjpeg::ByteSink* s) {
+    return sjpeg::EncodeNV12(y, y_step, uv, uv_step, W, H, param, s);
+  };
+  CHECK(!nv12(&Y[0], kWidth, &UV[0], uv_stride, kWidth, kHeight, nullptr));
+  CHECK(!nv12(nullptr, kWidth, &UV[0], uv_stride, kWidth, kHeight, sink));
+  CHECK(!nv12(&Y[0], kWidth, nullptr, uv_stride, kWidth, kHeight, sink));
+  CHECK(!nv12(&Y[0], kWidth, &UV[0], uv_stride, 0, kHeight, sink));
+  CHECK(!nv12(&Y[0], kWidth - 1, &UV[0], uv_stride, kWidth, kHeight, sink));
+  CHECK(!nv12(&Y[0], kWidth, &UV[0], uv_stride - 1, kWidth, kHeight, sink));
+  CHECK(!sjpeg::EncodeNV21(&Y[0], kWidth, &UV[0], uv_stride, kWidth, kHeight,
+                           param, nullptr));
+}
+
 TEST(QuantMatrix) {
   for (int quality = 0; quality <= 100; quality += 5) {
     for (int chroma = 0; chroma <= 1; ++chroma) {

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -298,6 +298,26 @@ TEST(MemoryManager) {
   }
 }
 
+// Dimensions are stored on 16 bits in the SOF marker. Anything larger must be
+// refused rather than silently truncated.
+TEST(LargeDimensions) {
+  const int kMaxDim = 0xffff, kSmallDim = 2;
+  const std::vector<uint8_t> rgb(
+      3 * static_cast<size_t>(kMaxDim + 1) * kSmallDim, 0x80);
+  const sjpeg::EncoderParam param(50.f);
+  std::string out;
+  CHECK(EncodeRGB(rgb, kMaxDim, kSmallDim, param, &out));
+  CHECK(HasSize(out, kMaxDim, kSmallDim));
+  CHECK(!EncodeRGB(rgb, kMaxDim + 1, kSmallDim, param, &out));
+  CHECK(!EncodeRGB(rgb, kSmallDim, kMaxDim + 1, param, &out));
+  CHECK(!sjpeg::EncodeGray(&rgb[0], kMaxDim + 1, kSmallDim, kMaxDim + 1,
+                           param, &out));
+  uint8_t* data = nullptr;
+  CHECK(SjpegEncode(&rgb[0], kMaxDim + 1, kSmallDim, 3 * (kMaxDim + 1), &data,
+                    50.f, 4, SJPEG_YUV_420) == 0);
+  CHECK(data == nullptr);
+}
+
 TEST(QuantMatrix) {
   for (int quality = 0; quality <= 100; quality += 5) {
     for (int chroma = 0; chroma <= 1; ++chroma) {


### PR DESCRIPTION
### Fixes

- **EncodeYUV420**: the clipped path read the U plane with `v_step_` — wrong output whenever the U and V strides differ.
- **dichotomy**: `StoreRunLevels()` ignored `CheckBuffers()` and wrote past `all_run_levels_` once an allocation failed.
- **bit_writer**: `Reserve()` left `buf_` dangling into memory the sink had just released.
- **SjpegEncode**: `EncoderFactory()` returns null for an unknown `yuv_mode` or on allocation failure, and the result was dereferenced unchecked.
- **Encoder**: `param.memory` was installed after construction, so blocks allocated by sub-class constructors were released by the wrong manager.
- **EncodeNV12/NV21**: arguments were validated after the base class had already used `output`, and the `uv_stride` bound was too small by half.
- **Encoder/SOF**: dimensions above 65535 were silently truncated into the SOF marker — 70000x2 encoded "successfully" as 4464x2.
- **SjpegDimensions**: rejected the null width/height that the header documents as optional, and scanned chunks with pointers built past the end of the buffer.
- **SjpegRiskiness**: the gray fraction was divided by `width * height` although the loop visits `(width-1) * (height-1)` samples, and flat tinted colors fell into the gray bucket.
- **HeaderSize**: charged two quantization matrices where `WriteDQT()` writes only one.
- **yuv_convert**: two `static bool done` guards, torn when two threads encode at once.

### Quality

- **tests**: self-contained unit-test binary, no external dependency — `make unit_test`, or `ctest` with CMake; the linux and macos CI jobs were building the tests without running them, and now run them.
- **ci**: pin `actions/checkout` to a commit hash instead of a movable tag (same version).
- **misc**: clamp the compression method instead of asserting on it, add a missing include, fix two wrong comments.

Each fix comes with the unit test that catches it.

### Note for review

Two commits may change the bitstream at byte level: **HeaderSize** (only
`YUV_400 + TARGET_SIZE`) and **SjpegRiskiness** (`YUV_AUTO`'s choice on gray
and flat tinted pictures, which is the point of the fix).

Please rebase-merge rather than squash, so the fixes stay bisectable.
