### PR TITLE
Makefile: detect the Homebrew / MacPorts prefix on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,11 @@ EXTRA_FLAGS += -std=c++11
 
 # OpenGL and GLUT
 ifeq ($(strip $(shell uname)), Darwin)
-  EXTRA_FLAGS += -I/opt/local/include
+  # Homebrew and MacPorts use different prefixes for libpng / libjpeg.
+  LOCAL_PREFIX = $(firstword $(wildcard /opt/homebrew /opt/local) /usr/local)
+  EXTRA_FLAGS += -I$(LOCAL_PREFIX)/include
   EXTRA_FLAGS += -Wno-deprecated-declarations
-  EXTRA_LIBS  += -L/opt/local/lib
+  EXTRA_LIBS  += -L$(LOCAL_PREFIX)/lib
   GL_LIBS = -framework GLUT -framework OpenGL
   EXTRA_FLAGS += -DHAVE_GLUT_GLUT_H
 else


### PR DESCRIPTION
The macOS branch of the Makefile hard-coded the MacPorts prefix, so a Homebrew
install fails with:

    examples/utils.cc:29:10: fatal error: 'png.h' file not found

Use the first prefix that is actually present instead.