### PR TITLE
dichotomy: derive ComputeSize() from the frequency table

### DIFF
--- a/src/dichotomy.cc
+++ b/src/dichotomy.cc
@@ -282,9 +282,18 @@ void Encoder::BlocksSize(int nb_mbs, const DCTCoeffs* coeffs,
 float Encoder::ComputeSize(const DCTCoeffs* coeffs) {
   InitCodes(false);
   size_t size = HeaderSize();
-  BitCounter bc;
-  BlocksSize(mb_w_ * mb_h_ * mcu_blocks_, coeffs, all_run_levels_, &bc);
-  size += bc.Size();
+  if (optimize_size_) {
+    // not counting the 0xff byte-stuffing that BlocksSize() tracks exactly
+    // these depends on the bit sequence, not on symbol counts.
+    // it's a little approximation we can live with.
+    // Under-estimated ~1/256 = 0.39%: uniform bytes, 0xff produces 2 bytes.
+    // Not worth correcting: below the search's own convergence precision.
+    size += EntropySize();
+  } else {
+    BitCounter bc;
+    BlocksSize(mb_w_ * mb_h_ * mcu_blocks_, coeffs, all_run_levels_, &bc);
+    size += bc.Size();
+  }
   return size / 8.f;
 }
 

--- a/src/entropy.cc
+++ b/src/entropy.cc
@@ -226,6 +226,24 @@ void Encoder::AddEntropyStats(const DCTCoeffs* const coeffs,
   ++freq_dc_[q_idx][coeffs->dc_code_ & 0x0f];
 }
 
+// Same total as BlocksSize(), minus uncounted 0xff byte-stuffing
+size_t Encoder::EntropySize() const {
+  size_t size = 0;
+  const int nb_tables = (nb_comps_ == 1) ? 1 : 2;
+  for (int q = 0; q < nb_tables; ++q) {
+    for (int len = 0; len < 12; ++len) {
+      const uint32_t freq = freq_dc_[q][len];
+      if (freq > 0) size += freq * ((dc_codes_[q][len] & 0xff) + len);
+    }
+    const uint32_t* const codes = ac_codes_[q];
+    for (int sym = 0; sym < 256; ++sym) {
+      const uint32_t freq = freq_ac_[q][sym];
+      if (freq > 0) size += freq * ((codes[sym] & 0xff) + (sym & 0x0f));
+    }
+  }
+  return size;
+}
+
 static int cmp(const void *pa, const void *pb) {
   const uint64_t a = *reinterpret_cast<const uint64_t*>(pa);
   const uint64_t b = *reinterpret_cast<const uint64_t*>(pb);

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -346,6 +346,7 @@ struct Encoder {
   void AddEntropyStats(const DCTCoeffs* const coeffs,
                        const RunLevel* const run_levels);
   void CompileEntropyStats();
+  size_t EntropySize() const;  // size, in bits, derived from freq_ac_/freq_dc_
 
   void SinglePassScan();           // finalizing scan
   void SinglePassScanOptimized();  // optimize the Huffman table + finalize scan


### PR DESCRIPTION
* StoreRunLevels() already gathers freq_ac_/freq_dc_ whenever optimize_size_ is set
=> which is always true at LoopScan()'s only call site.

* but ComputeSize() nevertheless still re-walked every run/level through a BitCounter,
  instead of using the frequency distribution already collected.

Using EntropySize() is faster (measured ~13% on multi-pass encodes) but a bit approximate
because it doesn't count the 0xff byte-stuffing (BitCounter does incorporate it).
Observed diff on Open Images corpus is 0.92% vs 0.90% before, acceptable.

The expected underestimation (neglecting 0xff-stuffing) is 1/256 (assuming uniform byte distribution, only 0xff produce two bytes instead of one), that's 0.39%. Not worth correcting the estimate with a wild-guess, it's under the convergence precision anyway.