### PR TITLE
Add AVX2 support and use it for StoreHisto, QuantizeBlock, and SjpegRiskiness

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -37,6 +37,24 @@ enc_srcs := \
         src/yuv_convert.$(NEON) \
         src/score_7.cc \
 
+# AVX2 kernel variants (x86 only, opt-in: 'ndk-build SJPEG_HAVE_AVX2=1').
+# A separate module, not part of enc_srcs above, because AVX2 needs its own
+# -mavx2 that must NOT apply to the rest of the library (unlike SSE2, AVX2
+# isn't a safe baseline assumption even on x86_64 -- support is picked at
+# runtime by SupportsAVX2() in src/enc.cc, same as the desktop build).
+ifneq ($(filter x86 x86_64, $(TARGET_ARCH_ABI)),)
+  ifeq ($(SJPEG_HAVE_AVX2),1)
+    include $(CLEAR_VARS)
+    LOCAL_SRC_FILES := src/histogram_avx2.cc src/quantize_avx2.cc
+    LOCAL_CFLAGS := $(SJPEG_CFLAGS) -mavx2
+    LOCAL_C_INCLUDES += $(LOCAL_PATH)/src
+    LOCAL_MODULE := sjpeg_avx2
+    include $(BUILD_STATIC_LIBRARY)
+    SJPEG_CFLAGS += -DSJPEG_HAVE_AVX2
+    SJPEG_AVX2_LIB := sjpeg_avx2
+  endif
+endif
+
 ################################################################################
 
 include $(CLEAR_VARS)
@@ -46,6 +64,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_CFLAGS := $(SJPEG_CFLAGS)
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/src
+LOCAL_WHOLE_STATIC_LIBRARIES := $(SJPEG_AVX2_LIB)
 
 # prefer arm over thumb mode for performance gains
 LOCAL_ARM_MODE := arm

--- a/Android.mk
+++ b/Android.mk
@@ -45,7 +45,8 @@ enc_srcs := \
 ifneq ($(filter x86 x86_64, $(TARGET_ARCH_ABI)),)
   ifeq ($(SJPEG_HAVE_AVX2),1)
     include $(CLEAR_VARS)
-    LOCAL_SRC_FILES := src/histogram_avx2.cc src/quantize_avx2.cc
+    LOCAL_SRC_FILES := src/histogram_avx2.cc src/quantize_avx2.cc \
+                       src/riskiness_avx2.cc
     LOCAL_CFLAGS := $(SJPEG_CFLAGS) -mavx2
     LOCAL_C_INCLUDES += $(LOCAL_PATH)/src
     LOCAL_MODULE := sjpeg_avx2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,13 @@ set(CMAKE_CXX_STANDARD 11)
 option(SJPEG_ENABLE_SIMD "Enable any SIMD optimization." ON)
 option(SJPEG_BUILD_EXAMPLES "Build the sjpeg / vjpeg command line tools." ON)
 option(SJPEG_BUILD_TESTS "Build the unit tests." ON)
+# Opt-in, off by default: unlike SSE2 (guaranteed on all x86-64) or NEON,
+# AVX2 isn't a safe baseline assumption, so it isn't part of the
+# SJPEG_SIMD_DEFINES loop in cmake/cpu.cmake (which applies its flag to the
+# whole target). Instead just src/*_avx2.cc gets -mavx2, and support is
+# picked at runtime (SupportsAVX2() in src/enc.cc), so a binary built with
+# this ON still runs on pre-Haswell CPUs.
+option(SJPEG_HAVE_AVX2 "Build the AVX2 kernel variants (x86 only)." OFF)
 
 set(SJPEG_DEP_LIBRARIES)
 set(SJPEG_DEP_INCLUDE_DIRS)
@@ -84,6 +91,25 @@ add_library(sjpeg ${CMAKE_CURRENT_SOURCE_DIR}/src/bit_writer.cc
 )
 if(SJPEG_DEP_LIBRARIES)
   target_link_libraries(sjpeg ${SJPEG_DEP_LIBRARIES})
+endif()
+
+if(SJPEG_HAVE_AVX2)
+  target_sources(sjpeg PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/histogram_avx2.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize_avx2.cc)
+  if(MSVC)
+    set(SJPEG_AVX2_FLAG "/arch:AVX2")
+  else()
+    set(SJPEG_AVX2_FLAG "-mavx2")
+  endif()
+  set_source_files_properties(
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/histogram_avx2.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize_avx2.cc
+    PROPERTIES COMPILE_OPTIONS "${SJPEG_AVX2_FLAG}"
+  )
+  # PUBLIC: unit_test / sjpeg-bin link against 'sjpeg' and need to see the
+  # same define (matches how SJPEG_HAVE_PNG/JPEG propagate below).
+  target_compile_definitions(sjpeg PUBLIC SJPEG_HAVE_AVX2)
 endif()
 
 # Make sure the OBJECT libraries are built with position independent code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,8 @@ endif()
 if(SJPEG_HAVE_AVX2)
   target_sources(sjpeg PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/histogram_avx2.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize_avx2.cc)
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize_avx2.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/riskiness_avx2.cc)
   if(MSVC)
     set(SJPEG_AVX2_FLAG "/arch:AVX2")
   else()
@@ -105,6 +106,7 @@ if(SJPEG_HAVE_AVX2)
   set_source_files_properties(
     ${CMAKE_CURRENT_SOURCE_DIR}/src/histogram_avx2.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize_avx2.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/riskiness_avx2.cc
     PROPERTIES COMPILE_OPTIONS "${SJPEG_AVX2_FLAG}"
   )
   # PUBLIC: unit_test / sjpeg-bin link against 'sjpeg' and need to see the

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,17 @@ EXTRA_FLAGS += -Wformat-security -Wformat-nonliteral
 # EXTRA_FLAGS += -march=armv7-a -mfloat-abi=hard -mfpu=neon -mtune=cortex-a8
 # -> seems to make the overall lib slower: -fno-split-wide-types
 
+# AVX2 support: opt-in, off by default. When on, the AVX2-specific files
+# (src/*_avx2.cc) are built with -mavx2 while the rest of the library stays
+# at its normal baseline -- AVX2 support is picked at runtime (SupportsAVX2()
+# in enc.cc), so the resulting binary still runs on non-AVX2 CPUs.
+# 'make HAVE_AVX2=1' to enable.
+HAVE_AVX2 ?= 0
+ifeq ($(HAVE_AVX2), 1)
+EXTRA_FLAGS += -DSJPEG_HAVE_AVX2
+src/%_avx2.o: EXTRA_FLAGS += -mavx2
+endif
+
 #### Nothing should normally be changed below this line ####
 
 AR = ar
@@ -81,6 +92,11 @@ SJPEG_OBJS = \
     src/quantize.o \
     src/score_7.o  \
     src/yuv_convert.o \
+
+ifeq ($(HAVE_AVX2), 1)
+SJPEG_OBJS += src/histogram_avx2.o
+SJPEG_OBJS += src/quantize_avx2.o
+endif
 
 UTILS_OBJS = \
     examples/utils.o \
@@ -201,8 +217,10 @@ DIST_FILES= \
          src/fdct.cc  \
          src/headers.cc \
          src/histogram.cc  \
+         src/histogram_avx2.cc  \
          src/jpeg_tools.cc  \
          src/quantize.cc  \
+         src/quantize_avx2.cc  \
          src/md5sum.h \
          src/score_7.cc  \
          src/sjpeg.h  \

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ SJPEG_OBJS = \
 ifeq ($(HAVE_AVX2), 1)
 SJPEG_OBJS += src/histogram_avx2.o
 SJPEG_OBJS += src/quantize_avx2.o
+SJPEG_OBJS += src/riskiness_avx2.o
 endif
 
 UTILS_OBJS = \
@@ -221,6 +222,7 @@ DIST_FILES= \
          src/jpeg_tools.cc  \
          src/quantize.cc  \
          src/quantize_avx2.cc  \
+         src/riskiness_avx2.cc  \
          src/md5sum.h \
          src/score_7.cc  \
          src/sjpeg.h  \

--- a/src/enc.cc
+++ b/src/enc.cc
@@ -173,6 +173,23 @@ bool SupportsNEON() {
   return false;
 }
 
+// unlike SSE2/NEON above, AVX2 support is a real runtime question even on a
+// binary built with AVX2 code paths compiled in (SJPEG_HAVE_AVX2): plenty of
+// deployed x86-64 CPUs predate Haswell. __builtin_cpu_supports() is itself
+// x86-only, so guard on the target too -- HAVE_AVX2=1 is meant for x86
+// builds, but nothing stops it being set by mistake (or by a generic CI
+// matrix) on another architecture, and this should degrade to "false"
+// there, not fail to compile.
+bool SupportsAVX2() {
+  if (ForceSlowCImplementation) return false;
+#if defined(SJPEG_HAVE_AVX2) && (defined(__i386__) || defined(__x86_64__))
+  __builtin_cpu_init();
+  return __builtin_cpu_supports("avx2") != 0;
+#else
+  return false;
+#endif
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // static pointers to architecture-dependant implementation
 

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -111,7 +111,17 @@ void StoreHisto(const int16_t in[64], Histo* const histos, int nb_blocks) {
   }
 }
 
+#if defined(SJPEG_HAVE_AVX2)
+// defined in histogram_avx2.cc, built separately with -mavx2 (see Makefile)
+// so this file itself doesn't need an AVX2 target.
+extern void StoreHistoAVX2(const int16_t in[64], Histo* const histos,
+                           int nb_blocks);
+#endif
+
 Encoder::StoreHistoFunc Encoder::GetStoreHistoFunc() {
+#if defined(SJPEG_HAVE_AVX2)
+  if (SupportsAVX2()) return StoreHistoAVX2;
+#endif
 #if defined(SJPEG_USE_SSE2)
   if (SupportsSSE2()) return StoreHistoSSE2;
 #elif defined(SJPEG_USE_NEON)

--- a/src/histogram_avx2.cc
+++ b/src/histogram_avx2.cc
@@ -1,0 +1,54 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  AVX2 variant of StoreHisto(), compiled with -mavx2 only for this file
+//  (see Makefile's src/%_avx2.o rule) so the rest of the library doesn't
+//  need to be built for an AVX2 target. 256-bit widening of StoreHistoSSE2
+//  in histogram.cc: same per-lane abs/shift/min, no cross-lane shuffle, so
+//  it doubles lane count 8 -> 16 with no algorithmic change. The trailing
+//  per-coefficient histogram increment stays scalar either way (data-
+//  dependent scatter, not vectorizable with AVX2).
+//
+// Author: Skal (pascal.massimino@gmail.com)
+
+#define SJPEG_NEED_ASM_HEADERS
+#include "sjpegi.h"
+
+#if defined(SJPEG_USE_AVX2)
+
+namespace sjpeg {
+
+void StoreHistoAVX2(const int16_t in[64], Histo* const histos,
+                    int nb_blocks) {
+  const __m256i kMaxHisto = _mm256_set1_epi16(MAX_HISTO_DCT_COEFF);
+  for (int n = 0; n < nb_blocks; ++n, in += 64) {
+    uint16_t tmp[64];
+    for (int i = 0; i < 64; i += 16) {
+      const __m256i A =
+          _mm256_loadu_si256(reinterpret_cast<const __m256i*>(in + i));
+      const __m256i C = _mm256_abs_epi16(A);
+      const __m256i D = _mm256_srli_epi16(C, HSHIFT);
+      const __m256i E = _mm256_min_epi16(D, kMaxHisto);
+      _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp + i), E);
+    }
+    for (int j = 0; j < 64; ++j) {
+      const int k = tmp[j];
+      ++histos->counts_[j][k];
+    }
+  }
+}
+
+}  // namespace sjpeg
+
+#endif  // SJPEG_USE_AVX2

--- a/src/histogram_avx2.cc
+++ b/src/histogram_avx2.cc
@@ -25,29 +25,40 @@
 #define SJPEG_NEED_ASM_HEADERS
 #include "sjpegi.h"
 
+#include <assert.h>
+
 #if defined(SJPEG_USE_AVX2)
 
 namespace sjpeg {
 
+#define LOAD_32(src) _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src))
+#define STORE_32(V, dst) \
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst), (V))
+
 void StoreHistoAVX2(const int16_t in[64], Histo* const histos,
                     int nb_blocks) {
+  assert(nb_blocks > 0);
   const __m256i kMaxHisto = _mm256_set1_epi16(MAX_HISTO_DCT_COEFF);
-  for (int n = 0; n < nb_blocks; ++n, in += 64) {
+  int n = 0;
+  do {
     uint16_t tmp[64];
     for (int i = 0; i < 64; i += 16) {
-      const __m256i A =
-          _mm256_loadu_si256(reinterpret_cast<const __m256i*>(in + i));
+      const __m256i A = LOAD_32(in + i);
       const __m256i C = _mm256_abs_epi16(A);
       const __m256i D = _mm256_srli_epi16(C, HSHIFT);
       const __m256i E = _mm256_min_epi16(D, kMaxHisto);
-      _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp + i), E);
+      STORE_32(E, tmp + i);
     }
     for (int j = 0; j < 64; ++j) {
       const int k = tmp[j];
       ++histos->counts_[j][k];
     }
-  }
+    in += 64;
+  } while (++n < nb_blocks);
 }
+
+#undef LOAD_32
+#undef STORE_32
 
 }  // namespace sjpeg
 

--- a/src/jpeg_tools.cc
+++ b/src/jpeg_tools.cc
@@ -175,9 +175,24 @@ static const double kThreshGray = 0.995;  // 1.00 = full gray (max)
 static const double kThreshYU420 = 40.0;
 static const double kThreshSharpYU420 = 70.0;
 
+#if defined(SJPEG_HAVE_AVX2) && defined(SJPEG_USE_AVX2_RISKINESS)
+namespace sjpeg {
+// defined in riskiness_avx2.cc, built separately with -mavx2 (see Makefile)
+// so this file itself doesn't need an AVX2 target.
+extern int RiskinessScoreRowAVX2(const uint16_t* row1, const uint16_t* row2,
+                                 int size, int noise_level,
+                                 int64_t* const score_sum,
+                                 int64_t* const score_num,
+                                 int64_t* const gray_num);
+}  // namespace sjpeg
+#endif
+
 SjpegYUVMode SjpegRiskiness(const uint8_t* rgb,
                             int width, int height, int stride, float* risk) {
   const sjpeg::RGBToIndexRowFunc cvrt_func = sjpeg::GetRowFunc();
+#if defined(SJPEG_HAVE_AVX2) && defined(SJPEG_USE_AVX2_RISKINESS)
+  const bool use_avx2_riskiness = sjpeg::SupportsAVX2();
+#endif
 
   std::vector<uint16_t> row1(width), row2(width);
   // Use faster int64_t accumulation instead of double. A score is at most
@@ -198,8 +213,16 @@ SjpegYUVMode SjpegRiskiness(const uint8_t* rgb,
     rgb += stride;
     std::swap(row1, row2);
     cvrt_func(rgb, width, &row2[0]);  // this is the row below
+    int i = 0;
+#if defined(SJPEG_HAVE_AVX2) && defined(SJPEG_USE_AVX2_RISKINESS)
+    if (use_avx2_riskiness) {
+      i = sjpeg::RiskinessScoreRowAVX2(&row1[0], &row2[0], width - 1,
+                                       kNoiseLevel, &score_sum, &score_num,
+                                       &gray_num);
+    }
+#endif
     SJPEG_UNROLL(4)
-    for (int i = 0; i < width - 1; ++i) {
+    for (; i < width - 1; ++i) {
       const int idx0 = row1[i + 0];
       const int idx1 = row1[i + 1];
       const int idx2 = row2[i + 0];

--- a/src/quantize.cc
+++ b/src/quantize.cc
@@ -43,7 +43,8 @@ const uint8_t kZigzag[64] = {
 // Inverse of kZigzag: maps a natural coefficient index to its zig-zag scan
 // position (kInvZigzag[kZigzag[i]] == i). Used by the SIMD run-length emitters
 // to turn a natural-order non-zero bitmask into a zig-zag-ordered one.
-static const uint8_t kInvZigzag[64] = {
+// Not static: quantize_avx2.cc (a separate TU) needs it too.
+const uint8_t kInvZigzag[64] = {
   0,   1,  5,  6, 14, 15, 27, 28,
   2,   4,  7, 13, 16, 26, 29, 42,
   3,   8, 12, 17, 25, 30, 41, 43,
@@ -456,7 +457,18 @@ int Encoder::TrellisQuantizeBlock(const int16_t in[64], int idx,
   return dc;
 }
 
+#if defined(SJPEG_HAVE_AVX2)
+// defined in quantize_avx2.cc, built separately with -mavx2 (see Makefile)
+// so this file itself doesn't need an AVX2 target.
+extern int QuantizeBlockAVX2(const int16_t in[64], int idx,
+                             const Quantizer* const Q, DCTCoeffs* const out,
+                             RunLevel* const rl);
+#endif
+
 Encoder::QuantizeBlockFunc Encoder::GetQuantizeBlockFunc() {
+#if defined(SJPEG_HAVE_AVX2)
+  if (SupportsAVX2()) return QuantizeBlockAVX2;
+#endif
 #if defined(SJPEG_USE_SSE2)
   if (SupportsSSE2()) return QuantizeBlockSSE2;
 #elif defined(SJPEG_USE_NEON)

--- a/src/quantize_avx2.cc
+++ b/src/quantize_avx2.cc
@@ -1,0 +1,108 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  AVX2 variant of QuantizeBlock(), compiled with -mavx2 only for this file
+//  (see Makefile's src/%_avx2.o rule). 256-bit widening of QuantizeBlockSSE2
+//  in quantize.cc: same per-lane abs/bias/mulhi/shift/sign-restore, no
+//  cross-lane shuffle needed there. The scalar tail (zig-zag remap + run/
+//  level emission, the dominant cost of this function -- see the
+//  SJPEG_HAVE_AVX2 commit message) is untouched, copied verbatim from
+//  QuantizeBlockSSE2.
+//
+//  One AVX2-specific wrinkle: _mm256_packs_epi16/_mm256_movemask_epi8
+//  operate per-128-bit-lane, not linearly across the full 256 bits (unlike
+//  their SSE2 counterparts), so packing+movemask-ing 16 lanes' worth of
+//  compare results does not give a contiguous 16-bit mask the way the
+//  8-lane SSE2 version's _mm_movemask_epi8(...) & 0xff does. The 32-bit
+//  result instead has the two real 8-bit halves (from the compare's low
+//  and high 128-bit lanes) 8 bits apart with a duplicate byte pair in
+//  between (m32 bits [8:15] and [24:31] are exact duplicates of [0:7] and
+//  [16:23], an artifact of packing 'cmp' against itself); compacted back to
+//  a real 16-bit mask with one shift+mask+or below.
+//
+// Author: Skal (pascal.massimino@gmail.com)
+
+#define SJPEG_NEED_ASM_HEADERS
+#include "sjpegi.h"
+
+#if defined(SJPEG_USE_AVX2)
+
+// uses BMI2 pext to compact the non-zero mask (2 ops vs 5). off by default:
+// pext is microcoded and slower on AMD Zen1/Zen+. needs -mbmi2 if enabled.
+// #define SJPEG_USE_PEXT
+
+namespace sjpeg {
+
+int QuantizeBlockAVX2(const int16_t in[64], int idx, const Quantizer* const Q,
+                      DCTCoeffs* const out, RunLevel* const rl) {
+  const uint16_t* const bias = Q->bias_;
+  const uint16_t* const iquant = Q->iquant_;
+  int prev = 1;
+  int nb = 0;
+  int16_t tmp[64], masked[64];
+  const __m256i zero = _mm256_setzero_si256();
+  uint64_t nzn = 0;  // natural-order non-zero mask: bit j set iff tmp[j] != 0.
+  for (int i = 0; i < 64; i += 16) {
+    const __m256i m_bias =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i*>(bias + i));
+    const __m256i m_mult =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i*>(iquant + i));
+    const __m256i A =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i*>(in + i));
+    const __m256i B = _mm256_srai_epi16(A, 15);  // sign (still needed below)
+    const __m256i C = _mm256_abs_epi16(A);        // abs(A)
+    const __m256i D = _mm256_adds_epi16(C, m_bias);            // v' = v+bias
+    const __m256i E = _mm256_mulhi_epu16(D, m_mult);           // (v'*iq)>>16
+    const __m256i F = _mm256_srli_epi16(E, AC_BITS);           // QUANTIZE(...)
+    const __m256i G = _mm256_xor_si256(F, B);                  // v ^ mask
+    _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp + i), F);
+    _mm256_storeu_si256(reinterpret_cast<__m256i*>(masked + i), G);
+    const __m256i cmp = _mm256_cmpgt_epi16(F, zero);
+#if defined(SJPEG_USE_PEXT)
+    const uint32_t m32 = static_cast<uint32_t>(_mm256_movemask_epi8(cmp));
+    const uint32_t m16 = static_cast<uint32_t>(_pext_u32(m32, 0x55555555u));
+#else
+    // compact the doubled/interleaved pack+movemask result to a real mask
+    const uint32_t m32 = static_cast<uint32_t>(
+        _mm256_movemask_epi8(_mm256_packs_epi16(cmp, cmp)));
+    const uint32_t m16 = (m32 & 0xff) | ((m32 >> 8) & 0xff00);
+#endif
+    nzn |= static_cast<uint64_t>(m16) << i;
+  }
+  // Emit run/level entries -- identical to QuantizeBlockSSE2/NEON/C, see
+  // quantize.cc for the explanation of this bit-trick zig-zag scan.
+  uint64_t zz = 0;
+  for (uint64_t b = nzn & ~1ull; b != 0; b &= b - 1) {
+    zz |= 1ull << kInvZigzag[TrailingZeros64(b)];
+  }
+  for (uint64_t b = zz; b != 0; b &= b - 1) {
+    const int i = static_cast<int>(TrailingZeros64(b));
+    const int j = kZigzag[i];
+    const int n = CalcLog2(tmp[j]);
+    const uint16_t code = masked[j] & ((1 << n) - 1);
+    rl[nb].level_ = (code << 4) | n;
+    rl[nb].run_ = i - prev;
+    prev = i + 1;
+    ++nb;
+  }
+  const int dc = (in[0] < 0) ? -tmp[0] : tmp[0];
+  out->idx_ = idx;
+  out->last_ = prev - 1;
+  out->nb_coeffs_ = nb;
+  return dc;
+}
+
+}  // namespace sjpeg
+
+#endif  // SJPEG_USE_AVX2

--- a/src/quantize_avx2.cc
+++ b/src/quantize_avx2.cc
@@ -38,8 +38,8 @@
 
 #if defined(SJPEG_USE_AVX2)
 
-// uses BMI2 pext to compact the non-zero mask (2 ops vs 5). off by default:
-// pext is microcoded and slower on AMD Zen1/Zen+. needs -mbmi2 if enabled.
+// Uses BMI2 pext to compact the non-zero mask (2 ops vs 5). Off by default:
+// pext is microcoded and slower on AMD Zen1/Zen+. Needs -mbmi2 if enabled.
 // #define SJPEG_USE_PEXT
 
 namespace sjpeg {

--- a/src/riskiness_avx2.cc
+++ b/src/riskiness_avx2.cc
@@ -1,0 +1,111 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// AVX2/gather variant of the inner loop of SjpegRiskiness() (jpeg_tools.cc).
+// This version uses 'gather' instruction, known to be slow on first-gen AVX2
+// hardware (Haswell/Broadwell).
+//
+// kSharpnessScore[] is a byte table but AVX2 has no byte gather. This gathers
+// dwords at scale=1 (byte-granular index, dword-aligned read) and masks the
+// low byte -- see score_7.cc: 3 extra trailing bytes for valid access.
+//
+// Author: Skal (pascal.massimino@gmail.com)
+
+#define SJPEG_NEED_ASM_HEADERS
+#include "sjpegi.h"
+
+#if defined(SJPEG_USE_AVX2) && defined(SJPEG_USE_AVX2_RISKINESS)
+
+namespace sjpeg {
+
+static inline int32_t HorizontalSumEpi32(__m256i v) {
+  const __m128i lo = _mm256_castsi256_si128(v);
+  const __m128i hi = _mm256_extracti128_si256(v, 1);
+  const __m128i sum = _mm_add_epi32(lo, hi);
+  int32_t tmp[4];
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(tmp), sum);
+  return tmp[0] + tmp[1] + tmp[2] + tmp[3];
+}
+
+// Processes 'size' samples in [0, size), 8 at a time.
+// Returns how many samples were actually consumed (a multiple of 8, <= size).
+// Caller needs to handle the [return value, size) remainder using C-version.
+int RiskinessScoreRowAVX2(const uint16_t* row1, const uint16_t* row2,
+                          int size, int noise_level,
+                          int64_t* const score_sum, int64_t* const score_num,
+                          int64_t* const gray_num) {
+  const int s = kRGBSize;
+  const int K = s * s * s;
+  const int gray = (s / 2) * (1 + s) * s;   // gray level for y=0,u=128,v=128
+  const int gray_min = gray - gray % s;
+
+  const int32_t* const table =
+      reinterpret_cast<const int32_t*>(kSharpnessScore);
+  const __m256i K_vec = _mm256_set1_epi32(K);
+  const __m256i noise_vec = _mm256_set1_epi32(noise_level);
+  const __m256i gray_min_m1_vec = _mm256_set1_epi32(gray_min - 1);
+  const __m256i gray_max_vec = _mm256_set1_epi32(gray_min + s);
+  const __m256i mask_ff = _mm256_set1_epi32(0xff);
+  const __m256i zero = _mm256_setzero_si256();
+
+  // 8-lane accumulators, reduced post-loop. Overflow-safe since kMaxDimension
+  // is 65535 => even the worst case (max score on every iteration) stays under
+  // 32bit limit (65534/8 * 765 ~= 6.3M)
+  __m256i sum_vec = zero;    // scores above the noise level
+  __m256i num_vec = zero;    // number of sum_vec
+  __m256i gray_vec = zero;   // samples with neutral chroma
+  int i = 0;
+  for (; i + 8 <= size; i += 8) {
+    const __m128i r1_0 =
+        _mm_loadu_si128(reinterpret_cast<const __m128i*>(row1 + i));
+    const __m128i r1_1 =
+        _mm_loadu_si128(reinterpret_cast<const __m128i*>(row1 + i + 1));
+    const __m128i r2_0 =
+        _mm_loadu_si128(reinterpret_cast<const __m128i*>(row2 + i));
+    const __m256i V0 = _mm256_cvtepu16_epi32(r1_0);   // idx0
+    const __m256i V1 = _mm256_cvtepu16_epi32(r1_1);   // idx1
+    const __m256i V2 = _mm256_cvtepu16_epi32(r2_0);   // idx2
+
+    const __m256i V1K = _mm256_mullo_epi32(V1, K_vec);
+    const __m256i V2K = _mm256_mullo_epi32(V2, K_vec);
+    const __m256i A = _mm256_add_epi32(V0, V1K);   // idx0 + K*idx1
+    const __m256i B = _mm256_add_epi32(V0, V2K);   // idx0 + K*idx2
+    const __m256i C = _mm256_add_epi32(V1, V2K);   // idx1 + K*idx2
+
+    const __m256i GA =
+        _mm256_and_si256(_mm256_i32gather_epi32(table, A, 1), mask_ff);
+    const __m256i GB =
+        _mm256_and_si256(_mm256_i32gather_epi32(table, B, 1), mask_ff);
+    const __m256i GC =
+        _mm256_and_si256(_mm256_i32gather_epi32(table, C, 1), mask_ff);
+    const __m256i score = _mm256_add_epi32(_mm256_add_epi32(GA, GB), GC);
+
+    const __m256i score_mask = _mm256_cmpgt_epi32(score, noise_vec);
+    const __m256i ge_mask = _mm256_cmpgt_epi32(V0, gray_min_m1_vec);
+    const __m256i lt_mask = _mm256_cmpgt_epi32(gray_max_vec, V0);
+    const __m256i gray_mask = _mm256_and_si256(ge_mask, lt_mask);
+
+    sum_vec = _mm256_add_epi32(sum_vec, _mm256_and_si256(score, score_mask));
+    num_vec = _mm256_sub_epi32(num_vec, score_mask);
+    gray_vec = _mm256_sub_epi32(gray_vec, gray_mask);
+  }
+  *score_sum += HorizontalSumEpi32(sum_vec);
+  *score_num += HorizontalSumEpi32(num_vec);
+  *gray_num += HorizontalSumEpi32(gray_vec);
+  return i;
+}
+
+}  // namespace sjpeg
+
+#endif  // SJPEG_USE_AVX2 && SJPEG_USE_AVX2_RISKINESS

--- a/src/score_7.cc
+++ b/src/score_7.cc
@@ -6215,6 +6215,8 @@ const uint8_t kSharpnessScore[] = {  // 114k
    7,  8,  9,  9,  4,  6,  6,  5,  5,  5,  6,  4,  4,  6,  3,  2,  2,  3,  2,
    5,  7,  6,  3,  2,  2,  4,  6,  8,  7,  4,  3,  2,  5,  7,  8,  8,  5,  3,
    0,
+  // pad: AVX2 gather reads dwords, needs 3 bytes past the last index
+   0,  0,  0,
 };
 
 }   // namespace sjpeg

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -55,6 +55,11 @@
 #define SJPEG_USE_AVX2
 #endif
 
+// Experimental: gather-based AVX2 riskiness scoring (src/riskiness_avx2.cc).
+// Off by default -- gather throughput is poor on first-gen AVX2 hardware
+// (Haswell/Broadwell), needs real measurement before it's on by default.
+// #define SJPEG_USE_AVX2_RISKINESS
+
 #if defined(__ARM_NEON__) || defined(__aarch64__)
 #define SJPEG_USE_NEON
 #endif

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -51,6 +51,10 @@
 #define SJPEG_USE_SSSE3
 #endif
 
+#if defined(__AVX2__)
+#define SJPEG_USE_AVX2
+#endif
+
 #if defined(__ARM_NEON__) || defined(__aarch64__)
 #define SJPEG_USE_NEON
 #endif
@@ -60,7 +64,9 @@
 #endif
 
 #if defined(SJPEG_NEED_ASM_HEADERS)
-#if defined(SJPEG_USE_SSSE3)
+#if defined(SJPEG_USE_AVX2)
+#include <immintrin.h>
+#elif defined(SJPEG_USE_SSSE3)
 #include <tmmintrin.h>
 #elif defined(SJPEG_USE_SSE2)
 #include <emmintrin.h>
@@ -79,6 +85,7 @@ namespace sjpeg {
 
 extern bool SupportsSSE2();
 extern bool SupportsNEON();
+extern bool SupportsAVX2();
 
 // Constants below are marker codes defined in JPEG spec
 // ISO/IEC 10918-1 : 1993(E) Table B.1
@@ -102,6 +109,7 @@ FdctFunc GetFdct();
 // these are the default luma/chroma matrices (JPEG spec section K.1)
 extern const uint8_t kDefaultMatrices[2][64];
 extern const uint8_t kZigzag[64];
+extern const uint8_t kInvZigzag[64];
 
 // scoring tables in score_7.cc
 extern const int kRGBSize;


### PR DESCRIPTION
* new flags and options: HAVE_AVX2 (Makefile) / SJPEG_HAVE_AVX2
  (CMake/Android.mk), off by default
* Picked at runtime via SupportsAVX2(), so a binary built with it still runs on pre-Haswell CPUs.
* new files: src/histogram_avx2.cc, src/quantize_avx2.cc, src/riskiness_avx2.cc
- StoreHisto: just 256-bit widening of StoreHistoSSE2. Measured -10.9% to -18.4% faster
- QuantizeBlock: Measured -3.9% faster. scalar zig-zag/run-level tail is still the slow part.
- Includes a commented-out SJPEG_USE_PEXT toggle for BMI2's PEXT
  (off by default — it's a risky instruction, esp. on AMD Zen1/Zen+)
- SjpegRiskiness: AVX2 gather for the score-table lookups, behind its own
  SJPEG_USE_AVX2_RISKINESS toggle (off by default).
  Measured -44% to -60% function speedup, -2.5% to -3.3% end to end.

- Overall (60 photos test, -q 0/75/95, AUTO mode, same x86 box): flat at q=0, -1.5% to -9% at q=75/95.
- Bit-exact against the existing SSE2/NEON/C paths in every test run
- Tested with parallel encoding too, for frequency scaling. Nothing conclusive to report.

Still TODO:
- Fdct-AVX2: need a totally new 256-bit shuffle/transpose
