### PR TITLE
small high-level code re-org

### DIFF
--- a/src/enc.cc
+++ b/src/enc.cc
@@ -124,7 +124,7 @@ void Encoder::SetCompressionMethod(int method) {
   optimize_size_ = (method != 0) && (method != 3);
   use_extra_memory_ = (method == 3) || (method == 4) || (method == 7);
   reuse_run_levels_ = (method == 1) || (method == 4) || (method == 5)
-                   || (method >= 7);
+                   || (method == 7);
   use_trellis_ = (method >= 7);
 }
 
@@ -391,6 +391,11 @@ void Encoder::SinglePassScanOptimized() {
 bool Encoder::Encode() {
   if (!ok_) return false;
 
+  // validate some input parameters
+  if (W_ <= 0 || H_ <= 0 || W_ > kMaxDimension || H_ > kMaxDimension) {
+    return SetError();
+  }
+
   FinalizeQuantMatrix(&quants_[0], q_bias_);
   FinalizeQuantMatrix(&quants_[1], q_bias_);
   SetCostCodes(0);
@@ -402,10 +407,6 @@ bool Encoder::Encode() {
   InitComponents();
   assert(nb_comps_ <= MAX_COMP);
   assert(mcu_blocks_ <= 6);
-  // validate some input parameters
-  if (W_ <= 0 || H_ <= 0 || W_ > kMaxDimension || H_ > kMaxDimension) {
-    return SetError();
-  }
 
   mb_w_ = (W_ + (block_w_ - 1)) / block_w_;
   mb_h_ = (H_ + (block_h_ - 1)) / block_h_;
@@ -423,28 +424,32 @@ bool Encoder::Encode() {
   if (passes_ > 1) {
     LoopScan();
   } else {
-    if (use_adaptive_quant_) {
-      // Histogram analysis + derive optimal quant matrices
-      CollectHistograms();
-      AnalyseHisto();
-    }
-
-    WriteDQT();
-    WriteSOF();
-
-    if (optimize_size_) {
-      SinglePassScanOptimized();
-    } else {
-      WriteDHT();
-      WriteSOS();
-      SinglePassScan();
-    }
+    SinglePassEncode();
   }
   WriteEOI();
   ok_ = ok_ && bw_.Finalize();
 
   DeallocateBlocks();
   return ok_;
+}
+
+void Encoder::SinglePassEncode() {
+  if (use_adaptive_quant_) {
+    // Histogram analysis + derive optimal quant matrices
+    CollectHistograms();
+    AnalyseHisto();
+  }
+
+  WriteDQT();
+  WriteSOF();
+
+  if (optimize_size_) {
+    SinglePassScanOptimized();
+  } else {
+    WriteDHT();
+    WriteSOS();
+    SinglePassScan();
+  }
 }
 
 }    // namespace sjpeg

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -375,6 +375,8 @@ struct Encoder {
   void SinglePassScan();           // finalizing scan
   void SinglePassScanOptimized();  // optimize the Huffman table + finalize scan
 
+  void SinglePassEncode();         // non-iterating encoding pass
+
   // quantize and compute run/levels from already stored coeffs
   void StoreRunLevels(DCTCoeffs* coeffs);
   // just write already stored run_levels & coeffs:
@@ -489,9 +491,6 @@ struct Encoder {
   bool have_coeffs_;          // true if the Fourier coefficients are stored
   bool AllocateBlocks(size_t num_blocks);  // returns false in case of error
   void DeallocateBlocks();
-
-  // these are for regular compression methods 0 or 2.
-  RunLevel base_run_levels_[64];
 
   // this is the extra memory for compression method 1
   RunLevel* all_run_levels_;


### PR DESCRIPTION
* Extract SinglePassEncode(), similar to LoopScan()
* move dimension check to the top of Encode()
* drop the dead base_run_levels_ member

* Also: fix reuse_run_levels_ for method 8:
  using 'method >= 7' wrongly enabled it, making method 8 incorrect
  in its memory consumption. Same output now, but less memory.
* tested bit-exact on al 780 combinations