### PR TITLE
Sharp YUV: early out at first iteration if already converged

### DIFF
--- a/src/yuv_convert.cc
+++ b/src/yuv_convert.cc
@@ -674,10 +674,8 @@ static bool PreprocessARGB(const uint8_t* const rgb, int width, int height,
                       (int)(3 * uv_w));
     }
     // test exit condition
-    if (iter > 0) {
-      if (diff_y_sum < diff_y_threshold) break;
-      if (diff_y_sum > prev_diff_y_sum) break;
-    }
+    if (diff_y_sum < diff_y_threshold) break;
+    if (iter > 0 && diff_y_sum > prev_diff_y_sum) break;
     prev_diff_y_sum = diff_y_sum;
   }
   // final reconstruction


### PR DESCRIPTION
Do a convergence test ("diff_y_sum < diff_y_threshold") right after
the 1rst iteration, for an early out.
The 'things are getting worse' test stays active after that, no change.

test: -32% on ApplySharpYUVConversion itself, isolated, over 300 test photos.

measured -8.7% speed-up end-to-end encode with default params.

it's not a bit-exact change, but measured difference is insignificant (<0.05dB)