### PR TITLE
sjpegi.h: remove unused NULL check/define

### DIFF
--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -28,10 +28,6 @@
 #include "bit_writer.h"
 // IWYU pragma: end_exports
 
-#ifndef NULL
-#define NULL 0
-#endif
-
 #define SJPEG_STRINGIFY_HELPER(x) #x
 #define SJPEG_STRINGIFY(x) SJPEG_STRINGIFY_HELPER(x)
 


### PR DESCRIPTION
`NULL` is not used in the code base since:
 927069e Replace NULL and 0 with nullptr in C++ code (#137)

The check itself was likely never needed unless there was a missed C
system include.
