### PR TITLE
Fix 32-bit overflow left over in PreprocessARGB's arena sizing

### DIFF
--- a/src/yuv_convert.cc
+++ b/src/yuv_convert.cc
@@ -596,9 +596,15 @@ static bool PreprocessARGB(const uint8_t* const rgb, int width, int height,
 
   // Single memory chunk allocation to avoid allocator lock contention and heap
   // fragmentation
-  const size_t total_elems = (w * 3 * 2) + (w * h) + (w * h) + (w * 2) +
-                             (uv_w * 3 * uv_h) + (uv_w * 3 * uv_h) +
-                             (uv_w * 3 * 1);
+  // 64-bit intermediate: size_t is only 32-bit on a 32-bit build, and this sum
+  // can overflow it well before reaching kMaxDimension (0xffff) on each side.
+  const uint64_t total_elems64 = ((uint64_t)w * 3 * 2) + ((uint64_t)w * h) +
+                                 ((uint64_t)w * h) + ((uint64_t)w * 2) +
+                                 ((uint64_t)uv_w * 3 * uv_h) +
+                                 ((uint64_t)uv_w * 3 * uv_h) +
+                                 ((uint64_t)uv_w * 3 * 1);
+  if (total_elems64 > SIZE_MAX / sizeof(uint16_t)) return false;
+  const size_t total_elems = (size_t)total_elems64;
   std::unique_ptr<uint16_t[]> arena(new (std::nothrow) uint16_t[total_elems]);
   if (arena == nullptr) return false;
 


### PR DESCRIPTION
a51b9ee promoted PreprocessARGB's w/h/uv_w/uv_h/total_elems to size_t to fix
overflow in w*h. That fixes it on a 64-bit size_t, but not on a 32-bit one:
kMaxDimension is 65535, so w*h alone reaches 65536*65536 = 2^32, which
already wraps a 32-bit size_t to 0 before total_elems even sums its other
terms. The wrapped, undersized total_elems then goes straight into
`new uint16_t[total_elems]`, which succeeds with a too-small buffer.

Widens the total_elems sum to a uint64_t intermediate (casting each
multiplicand, not just the pre-computed size_t products) and bails out with
`return false` if it doesn't fit in a size_t on this platform, before ever
narrowing and allocating. ConvertWRGBToYUV's own size_t index math is
covered transitively, since it only runs after PreprocessARGB's allocation
already succeeded.

No-op on 64-bit and for any image within a realistic size range: verified
bit-exact on a real photo before/after the change.