### PR TITLE
Progressive coding: memory-safety and clarity fixes

### DIFF
--- a/src/enc.cc
+++ b/src/enc.cc
@@ -76,7 +76,6 @@ Encoder::Encoder(SjpegYUVMode yuv_mode, int W, int H, ByteSink* const sink,
     max_run_levels_(0),
     qdelta_max_luma_(kDefaultDeltaMaxLuma),
     qdelta_max_chroma_(kDefaultDeltaMaxChroma),
-    progressive_(false),
     prog_luma_split_(64), prog_chroma_split_(8),
     prog_planes_(nullptr),
     passes_(1),
@@ -139,15 +138,13 @@ void Encoder::SetProgressive(int luma_split, int chroma_split) {
   luma_split = (luma_split < 1) ? 1 : (luma_split > 64) ? 64 : luma_split;
   chroma_split = (chroma_split < 1) ? 1 : (chroma_split > 64) ? 64
                                                               : chroma_split;
-  progressive_ = (luma_split < 64);
   prog_luma_split_ = luma_split;
   prog_chroma_split_ = chroma_split;
   // use_extra_memory_/reuse_run_levels_ are baseline-only; EncodeProgressive()
   // has its own storage and doesn't need either of them.
 #else
   (void)luma_split;
-  (void)chroma_split;
-  progressive_ = false;  // not compiled in: silently a no-op
+  (void)chroma_split;  // not compiled in: silently a no-op
 #endif
 }
 
@@ -290,8 +287,7 @@ bool Encoder::AllocateBlocks(size_t num_blocks) {
 }
 
 void Encoder::DeallocateBlocks() {
-  Free(in_blocks_base_);
-  in_blocks_base_ = nullptr;
+  FreePtr(&in_blocks_base_);
   in_blocks_ = nullptr;          // sanity
 }
 
@@ -302,6 +298,12 @@ void Encoder::TransformMCU(int mb_x, int mb_y, int16_t* const out) {
   const bool yclip = (mb_y == mb_y_max_);
   GetSamples(mb_x, mb_y, yclip | (mb_x == mb_x_max_), out);
   fDCT_(out, mcu_blocks_);
+}
+
+void Encoder::MaybeTransformMCU(int mb_x, int mb_y, int16_t** const in) {
+  if (have_coeffs_) return;
+  *in = in_blocks_;
+  TransformMCU(mb_x, mb_y, *in);
 }
 
 void Encoder::CollectCoeffs() {
@@ -326,14 +328,10 @@ void Encoder::SinglePassScan() {
   int16_t* in = in_blocks_;
   const QuantizeBlockFunc quantize_block = use_trellis_ ? TrellisQuantizeBlock
                                                         : quantize_block_;
-  const bool have_coeffs = have_coeffs_;
   for (int mb_y = 0; mb_y < mb_h_; ++mb_y) {
     for (int mb_x = 0; mb_x < mb_w_; ++mb_x) {
       if (!CheckBuffers()) return;
-      if (!have_coeffs) {
-        in = in_blocks_;
-        TransformMCU(mb_x, mb_y, in);
-      }
+      MaybeTransformMCU(mb_x, mb_y, &in);
       for (int c = 0; c < nb_comps_; ++c) {
         DCTCoeffs base_coeffs;
         for (int i = 0; i < nb_blocks_[c]; ++i) {
@@ -379,14 +377,10 @@ void Encoder::SinglePassScanOptimized() {
   ResetDCs();
   nb_run_levels_ = 0;
   int16_t* in = in_blocks_;
-  const bool have_coeffs = have_coeffs_;
   const bool reuse_run_levels = reuse_run_levels_;
   for (int mb_y = 0; mb_y < mb_h_; ++mb_y) {
     for (int mb_x = 0; mb_x < mb_w_; ++mb_x) {
-      if (!have_coeffs) {
-        in = in_blocks_;
-        TransformMCU(mb_x, mb_y, in);
-      }
+      MaybeTransformMCU(mb_x, mb_y, &in);
       if (!CheckBuffers()) goto End;
       for (int c = 0; c < nb_comps_; ++c) {
         for (int i = 0; i < nb_blocks_[c]; ++i) {
@@ -485,13 +479,15 @@ void Encoder::SinglePassEncode() {
   WriteDQT();
 
 #if !defined(SJPEG_NO_PROGRESSIVE)
-  if (progressive_) {
+  // progressive path: must be after WriteDQT() and before WriteSOF()
+  if (prog_luma_split_ < 64) {  // needs progressive coding?
     WriteSOF(/*progressive=*/true);
-    EncodeProgressive();
+    if (!EncodeProgressive()) SetError();
     return;
   }
 #endif
 
+  // baseline coding
   WriteSOF();
 
   if (optimize_size_) {

--- a/src/prog.cc
+++ b/src/prog.cc
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-//  Progressive (spectral-split-only) mode: raster-ordered per-component
-//  planes, and the DC / AC scan drivers.
+//  Progressive mode (spectral-split-only)
 //
 // Author: Skal (pascal.massimino@gmail.com)
 
@@ -53,7 +52,11 @@ bool Encoder::AllocateProgPlanes() {
         (size_t)prog_planes_->plane_w[c] * prog_planes_->plane_h[c];
     prog_planes_->coeffs[c] = Alloc<DCTCoeffs>(nb_blocks);
     if (prog_planes_->coeffs[c] == nullptr) return false;
-    prog_planes_->run_levels[c] = Alloc<RunLevel>(nb_blocks * 63);
+    // Need uint64_t cast here, not size_t (which is 32bit on 32-bit build).
+    // Note: nb_blocks * 63 can overflow 32bit.
+    const uint64_t nb_run_levels = (uint64_t)nb_blocks * 63;
+    if (nb_run_levels > SIZE_MAX / sizeof(RunLevel)) return SetError();
+    prog_planes_->run_levels[c] = Alloc<RunLevel>((size_t)nb_run_levels);
     if (prog_planes_->run_levels[c] == nullptr) return false;
   }
   return true;
@@ -65,8 +68,7 @@ void Encoder::DeallocateProgPlanes() {
     Free(prog_planes_->coeffs[c]);
     Free(prog_planes_->run_levels[c]);
   }
-  Free(prog_planes_);
-  prog_planes_ = nullptr;
+  FreePtr(&prog_planes_);
 }
 
 int Encoder::ProgPlaneIndex(int c, int mb_x, int mb_y, int i) const {
@@ -78,6 +80,8 @@ int Encoder::ProgPlaneIndex(int c, int mb_x, int mb_y, int i) const {
 }
 
 bool Encoder::CheckProgBuffers() {
+  // progressive mode doesn't use all_run_levels_ => no growth needed here,
+  // unlike CheckBuffers().
   return ReserveSlab();
 }
 
@@ -162,19 +166,17 @@ bool Encoder::EncodeProgressive() {
   ResetDCs();
   if (!AllocateProgPlanes()) return false;
 
-  // 1. Quantize every block once into the raster-ordered planes.
+  // 1. Quantize every block once, gathering DC entropy stats along the way.
+  // Same mb_y/mb_x/c/i nest as the DC-code pass below -- keep them in sync.
   const QuantizeBlockFunc quantize_block =
       use_trellis_ ? TrellisQuantizeBlock : quantize_block_;
   // trellis needs ac_codes_[] seeded, like the baseline path does
   if (use_trellis_) InitCodes(true);
-  const bool have_coeffs = have_coeffs_;
+  memset(freq_dc_, 0, sizeof(freq_dc_));
   int16_t* in = in_blocks_;
   for (int mb_y = 0; mb_y < mb_h_; ++mb_y) {
     for (int mb_x = 0; mb_x < mb_w_; ++mb_x) {
-      if (!have_coeffs) {
-        in = in_blocks_;
-        TransformMCU(mb_x, mb_y, in);
-      }
+      MaybeTransformMCU(mb_x, mb_y, &in);
       for (int c = 0; c < nb_comps_; ++c) {
         for (int i = 0; i < nb_blocks_[c]; ++i) {
           const int idx = ProgPlaneIndex(c, mb_x, mb_y, i);
@@ -183,30 +185,24 @@ bool Encoder::EncodeProgressive() {
           const int dc = quantize_block(in, c, &quants_[quant_idx_[c]],
                                         coeffs, run_levels);
           coeffs->dc_code_ = GenerateDCDiffCode(dc, &DCs_[c]);
+          AddEntropyStatsDC(coeffs);
           in += 64;
         }
       }
     }
   }
+  DeallocateBlocks();     // we can free up some coeffs memory at this point
   if (!ok_) {
     DeallocateProgPlanes();
     return false;
   }
 
   // 2. DC scan: one interleaved scan, baseline MCU order.
-  memset(freq_dc_, 0, sizeof(freq_dc_));
-  for (int mb_y = 0; mb_y < mb_h_; ++mb_y) {
-    for (int mb_x = 0; mb_x < mb_w_; ++mb_x) {
-      for (int c = 0; c < nb_comps_; ++c) {
-        for (int i = 0; i < nb_blocks_[c]; ++i) {
-          const int idx = ProgPlaneIndex(c, mb_x, mb_y, i);
-          AddEntropyStatsDC(&prog_planes_->coeffs[c][idx]);
-        }
-      }
-    }
-  }
   CompileEntropyStatsDC();
-  if (!CheckProgBuffers()) return false;
+  if (!CheckProgBuffers()) {
+    DeallocateProgPlanes();
+    return false;
+  }
   {
     ScanComponent scs[MAX_COMP];
     for (int c = 0; c < nb_comps_; ++c) {
@@ -218,7 +214,10 @@ bool Encoder::EncodeProgressive() {
   }
   for (int mb_y = 0; mb_y < mb_h_; ++mb_y) {
     for (int mb_x = 0; mb_x < mb_w_; ++mb_x) {
-      if (!CheckProgBuffers()) return false;
+      if (!CheckProgBuffers()) {
+        DeallocateProgPlanes();
+        return false;
+      }
       for (int c = 0; c < nb_comps_; ++c) {
         for (int i = 0; i < nb_blocks_[c]; ++i) {
           const int idx = ProgPlaneIndex(c, mb_x, mb_y, i);
@@ -229,10 +228,14 @@ bool Encoder::EncodeProgressive() {
   }
   bw_.Flush();
 
-  // 3. AC scans: luma, then chroma.
+  // 3. AC scans: luma, then chroma; free each component right after its scan.
   EncodeProgAC(0, prog_luma_split_);
+  FreePtr(&prog_planes_->coeffs[0]);
+  FreePtr(&prog_planes_->run_levels[0]);
   for (int c = 1; c < nb_comps_; ++c) {
     EncodeProgAC(c, prog_chroma_split_);
+    FreePtr(&prog_planes_->coeffs[c]);
+    FreePtr(&prog_planes_->run_levels[c]);
   }
 
   DeallocateProgPlanes();

--- a/src/sjpeg.h
+++ b/src/sjpeg.h
@@ -240,6 +240,8 @@ struct EncoderParam {
   // Progressive JPEG encoding. *_split (1..63) is the low/high frequency
   // split point for luma/chroma; luma_split==64 (default) turns it off.
   // 2/8 is a good starting point (see '-progressive' in the sjpeg CLI).
+  // Not supported together with multi-pass search (passes > 1): the search
+  // takes over and produces a non-progressive file instead.
   int progressive_luma_split;
   int progressive_chroma_split;
 

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -414,6 +414,10 @@ struct Encoder {
   // and progressive quantize loops.
   void TransformMCU(int mb_x, int mb_y, int16_t* const out);
 
+  // TransformMCU() unless coefficients are already cached. Shared guard for
+  // SinglePassScan(), SinglePassScanOptimized(), EncodeProgressive().
+  void MaybeTransformMCU(int mb_x, int mb_y, int16_t** const in);
+
   // collect transformed coeffs (unquantized) only
   void CollectCoeffs();
 
@@ -519,6 +523,11 @@ struct Encoder {
   template<class T> void Free(T* const ptr) {
     memory_hook_->Free(reinterpret_cast<void*>(ptr));
   }
+  // Free(*ptr) followed by '*ptr = nullptr', as a single safe step.
+  template<class T> void FreePtr(T** const ptr) {
+    Free(*ptr);
+    *ptr = nullptr;
+  }
 
  protected:
   bool ok_;                // set to false if a new[] fails
@@ -588,7 +597,7 @@ struct Encoder {
   Histo histos_[2];
 
   // --- progressive (spectral-split-only) mode. See SetProgressive(). ---
-  bool progressive_;                          // true if -prog mode is active
+  // prog_luma_split_ == 64 means progressive mode is off.
   int prog_luma_split_, prog_chroma_split_;   // Se of the low band, or >=63
 
   // Per-component planes + scratch AC-Huffman state. Allocated by
@@ -617,7 +626,7 @@ struct Encoder {
   };
   bool AllocateProgPlanes();
   void DeallocateProgPlanes();
-  // index of sub-block 'i' of MCU (mb_x,mb_y) in component c's plane.
+  // index of sub-block 'i' of MCU (mb_x,mb_y) in component c's plane
   int ProgPlaneIndex(int c, int mb_x, int mb_y, int i) const;
   bool CheckProgBuffers();  // like CheckBuffers(), but for the bw_ slab only
   void EncodeProgAC(int c, int split);  // all AC scans for one component


### PR DESCRIPTION
- AllocateProgPlanes(): guard run_levels sizing against 32-bit overflow
- EncodeProgressive(): free prog_planes_ on the two DC-scan error
  paths that skipped it
- EncodeProgressive(): free in_blocks_ right after the quantize pass
- EncodeProgressive(): free each component's storage right after its
  own AC scan
- SinglePassEncode(): check EncodeProgressive()'s return value instead
  of relying on the ok_ side effect
- sjpeg.h: document that -prog is dropped under multi-pass search
- SinglePassEncode(): note the progressive dispatch's ordering
  constraint
- CheckProgBuffers(): document why it skips all_run_levels_ growth
- extract the shared have_coeffs_/TransformMCU() guard into
  MaybeTransformMCU()
- EncodeProgressive(): fold the DC-stats pass into the quantize pass
- drop the redundant progressive_ field (prog_luma_split_ < 64 says
  the same thing)
- add FreePtr(): Free()+null a pointer in one call, applied at
  existing call sites