### PR TITLE
Add gather-based AVX2 variant of SharpYUV gamma-table lookups

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -56,7 +56,8 @@ ifneq ($(filter x86 x86_64, $(TARGET_ARCH_ABI)),)
   ifeq ($(SJPEG_HAVE_AVX2),1)
     include $(CLEAR_VARS)
     LOCAL_SRC_FILES := src/fdct_avx2.cc src/histogram_avx2.cc \
-                       src/quantize_avx2.cc src/riskiness_avx2.cc
+                       src/quantize_avx2.cc src/riskiness_avx2.cc \
+                       src/yuv_convert_avx2.cc
     LOCAL_CFLAGS := $(SJPEG_CFLAGS) -mavx2
     LOCAL_C_INCLUDES += $(LOCAL_PATH)/src
     LOCAL_MODULE := sjpeg_avx2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,8 @@ if(SJPEG_HAVE_AVX2)
     ${CMAKE_CURRENT_SOURCE_DIR}/src/fdct_avx2.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/histogram_avx2.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize_avx2.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/riskiness_avx2.cc)
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/riskiness_avx2.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/yuv_convert_avx2.cc)
   if(MSVC)
     set(SJPEG_AVX2_FLAG "/arch:AVX2")
   else()
@@ -118,6 +119,7 @@ if(SJPEG_HAVE_AVX2)
     ${CMAKE_CURRENT_SOURCE_DIR}/src/histogram_avx2.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize_avx2.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/riskiness_avx2.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/yuv_convert_avx2.cc
     PROPERTIES COMPILE_OPTIONS "${SJPEG_AVX2_FLAG}"
   )
   # PUBLIC: unit_test / sjpeg-bin link against 'sjpeg' and need to see the

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ SJPEG_OBJS += src/fdct_avx2.o
 SJPEG_OBJS += src/histogram_avx2.o
 SJPEG_OBJS += src/quantize_avx2.o
 SJPEG_OBJS += src/riskiness_avx2.o
+SJPEG_OBJS += src/yuv_convert_avx2.o
 endif
 
 UTILS_OBJS = \
@@ -242,6 +243,7 @@ DIST_FILES= \
          src/sjpeg.h  \
          src/sjpegi.h  \
          src/yuv_convert.cc \
+         src/yuv_convert_avx2.cc \
          man/sjpeg.1  \
          man/vjpeg.1  \
          examples/Android.mk  \

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -55,9 +55,12 @@
 #endif
 
 // Experimental: gather-based AVX2 riskiness scoring (src/riskiness_avx2.cc).
-// Off by default -- gather throughput is poor on first-gen AVX2 hardware
-// (Haswell/Broadwell), needs real measurement before it's on by default.
+// Off by default (gather throughput is erratic on early AVX2 hardware)
 // #define SJPEG_USE_AVX2_RISKINESS
+
+// Gather-based AVX2 variant of the Sharp RGB->YUV gamma-table lookups
+// Bit-exact with C-variant, ~1.15x faster.
+#define SJPEG_USE_AVX2_YUV_GATHER
 
 #if defined(__ARM_NEON__) || defined(__aarch64__)
 #define SJPEG_USE_NEON
@@ -151,6 +154,10 @@ bool ApplySharpYUVConversion(const uint8_t* const rgb,
                              uint8_t* y_plane,
                              uint8_t* u_plane,
                              uint8_t* v_plane);
+
+// Shared by yuv_convert.cc and yuv_convert_avx2.cc.
+typedef int16_t fixed_t;
+typedef uint16_t fixed_y_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Generic sample-replication function. Replicate sub_w x sub_h area of 'src'

--- a/src/yuv_convert.cc
+++ b/src/yuv_convert.cc
@@ -38,8 +38,6 @@ namespace sjpeg {
 #define SFIX 2                // fixed-point precision of RGB and Y/W
 #define SHALF (1 << SFIX >> 1)
 #define MAX_Y_T ((256 << SFIX) - 1)
-typedef int16_t fixed_t;      // signed type with extra SFIX precision for UV
-typedef uint16_t fixed_y_t;   // unsigned type with extra SFIX precision for W
 
 static fixed_y_t clip_y(int y) {
   return (!(y & ~MAX_Y_T)) ? (fixed_y_t)y : (y < 0) ? 0 : MAX_Y_T;
@@ -111,9 +109,9 @@ static const int kMinDimensionIterativeConversion = 4;
 
 // size of the interpolation table for linear-to-gamma
 #define GAMMA_TABLE_SIZE 32
-static uint32_t kLinearToGammaTab[GAMMA_TABLE_SIZE + 2];
+uint32_t kLinearToGammaTab[GAMMA_TABLE_SIZE + 2];
 #define GAMMA_TO_LINEAR_BITS 14
-static uint32_t kGammaToLinearTab[MAX_Y_T + 1];   // size scales with Y_FIX
+uint32_t kGammaToLinearTab[MAX_Y_T + 1];   // size scales with Y_FIX
 
 static void InitGammaTablesF() {
   static std::once_flag once;
@@ -157,9 +155,14 @@ static void InitGammaTablesF() {
 }
 
 // return value has a fixed-point precision of GAMMA_TO_LINEAR_BITS
-static uint32_t GammaToLinear(int v) { return kGammaToLinearTab[v]; }
+// (used by yuv_convert_avx2.cc too)
+uint32_t GammaToLinear(int v) { return kGammaToLinearTab[v]; }
 
-static uint32_t LinearToGamma(uint32_t value) {
+// TODO(skal): return range is currently [8192, 9215], and not [0, MAX_Y_T]!
+// => kLinearToGammaTab[] bakes the rounding bias into the entries.
+// It's ok since we're only using diffs of these, but it's a ticking bomb.
+// TODO(skal): remove the +8192 offset.
+uint32_t LinearToGamma(uint32_t value) {
   // 'value' is in GAMMA_TO_LINEAR_BITS fractional precision
   const uint32_t v = value * GAMMA_TABLE_SIZE;
   const uint32_t tab_pos = v >> GAMMA_TO_LINEAR_BITS;
@@ -404,12 +407,26 @@ static void SharpFilterRow_NEON(const int16_t* A, const int16_t* B, int len,
 
 #endif    // SJPEG_USE_NEON
 
+// forward decls for InitFunctionPointers() below
+static void UpdateW(const fixed_y_t* src, fixed_y_t* dst, int w);
+static void UpdateChroma(const fixed_y_t* src1, const fixed_y_t* src2,
+                         fixed_t* dst, size_t uv_w);
+
 static uint64_t (*kSharpUpdateY)(const uint16_t* src, const uint16_t* ref,
                                  uint16_t* dst, int len);
 static void (*kSharpUpdateRGB)(const int16_t* src, const int16_t* ref,
                                int16_t* dst, int len);
 static void (*kSharpFilterRow)(const int16_t* A, const int16_t* B,
                                int len, const uint16_t* best_y, uint16_t* out);
+static void (*kUpdateW)(const fixed_y_t* src, fixed_y_t* dst, int w);
+static void (*kUpdateChroma)(const fixed_y_t* src1, const fixed_y_t* src2,
+                             fixed_t* dst, size_t uv_w);
+
+#if defined(SJPEG_HAVE_AVX2) && defined(SJPEG_USE_AVX2_YUV_GATHER)
+extern void UpdateWAVX2(const fixed_y_t* src, fixed_y_t* dst, int w);
+extern void UpdateChromaAVX2(const fixed_y_t* src1, const fixed_y_t* src2,
+                             fixed_t* dst, size_t uv_w);
+#endif
 
 static void InitFunctionPointers() {
   static std::once_flag once;
@@ -417,6 +434,8 @@ static void InitFunctionPointers() {
     kSharpUpdateY = SharpUpdateY_C;
     kSharpUpdateRGB = SharpUpdateRGB_C;
     kSharpFilterRow = SharpFilterRow_C;
+    kUpdateW = UpdateW;
+    kUpdateChroma = UpdateChroma;
 #if defined(SJPEG_USE_SSE2)
     if (sjpeg::SupportsSSE2()) {
       kSharpUpdateY = SharpUpdateY_SSE2;
@@ -431,17 +450,23 @@ static void InitFunctionPointers() {
       kSharpFilterRow = SharpFilterRow_NEON;
     }
 #endif
+#if defined(SJPEG_HAVE_AVX2) && defined(SJPEG_USE_AVX2_YUV_GATHER)
+    if (sjpeg::SupportsAVX2()) {
+      kUpdateW = UpdateWAVX2;
+      kUpdateChroma = UpdateChromaAVX2;
+    }
+#endif
   });
 }
 
 //------------------------------------------------------------------------------
 
-static uint32_t RGBToGray(uint32_t r, uint32_t g, uint32_t b) {
+uint32_t RGBToGray(uint32_t r, uint32_t g, uint32_t b) {
   const uint32_t luma = 13933 * r + 46871 * g + 4732 * b + (1u << YUV_FIX >> 1);
   return (luma >> YUV_FIX);
 }
 
-static uint32_t ScaleDown(int a, int b, int c, int d) {
+uint32_t ScaleDown(int a, int b, int c, int d) {
   const uint32_t A = GammaToLinear(a);
   const uint32_t B = GammaToLinear(b);
   const uint32_t C = GammaToLinear(c);
@@ -646,9 +671,9 @@ static bool PreprocessARGB(const uint8_t* const rgb, int width, int height,
     }
     StoreGray(src1, &best_y[y_off + 0], w);
     StoreGray(src2, &best_y[y_off + w], w);
-    UpdateW(src1, &target_y[y_off + 0], w);
-    UpdateW(src2, &target_y[y_off + w], w);
-    UpdateChroma(src1, src2, &target_uv[uv_off], uv_w);
+    kUpdateW(src1, &target_y[y_off + 0], w);
+    kUpdateW(src2, &target_y[y_off + w], w);
+    kUpdateChroma(src1, src2, &target_uv[uv_off], uv_w);
     memcpy(&best_uv[uv_off], &target_uv[uv_off], 3 * uv_w * sizeof(best_uv[0]));
   }
 
@@ -669,9 +694,9 @@ static bool PreprocessARGB(const uint8_t* const rgb, int width, int height,
       prev_uv = cur_uv;
       cur_uv = next_uv;
 
-      UpdateW(src1, &best_rgb_y[0 * w], (int)w);
-      UpdateW(src2, &best_rgb_y[1 * w], (int)w);
-      UpdateChroma(src1, src2, &best_rgb_uv[0], (int)uv_w);
+      kUpdateW(src1, &best_rgb_y[0 * w], (int)w);
+      kUpdateW(src2, &best_rgb_y[1 * w], (int)w);
+      kUpdateChroma(src1, src2, &best_rgb_uv[0], (int)uv_w);
 
       // update two rows of Y and one row of RGB
       diff_y_sum += kSharpUpdateY(&target_y[y_off], &best_rgb_y[0],

--- a/src/yuv_convert.cc
+++ b/src/yuv_convert.cc
@@ -423,9 +423,9 @@ static void (*kUpdateChroma)(const fixed_y_t* src1, const fixed_y_t* src2,
                              fixed_t* dst, size_t uv_w);
 
 #if defined(SJPEG_HAVE_AVX2) && defined(SJPEG_USE_AVX2_YUV_GATHER)
-extern void UpdateWAVX2(const fixed_y_t* src, fixed_y_t* dst, int w);
-extern void UpdateChromaAVX2(const fixed_y_t* src1, const fixed_y_t* src2,
-                             fixed_t* dst, size_t uv_w);
+extern void UpdateW_AVX2(const fixed_y_t* src, fixed_y_t* dst, int w);
+extern void UpdateChroma_AVX2(const fixed_y_t* src1, const fixed_y_t* src2,
+                               fixed_t* dst, size_t uv_w);
 #endif
 
 static void InitFunctionPointers() {
@@ -452,8 +452,8 @@ static void InitFunctionPointers() {
 #endif
 #if defined(SJPEG_HAVE_AVX2) && defined(SJPEG_USE_AVX2_YUV_GATHER)
     if (sjpeg::SupportsAVX2()) {
-      kUpdateW = UpdateWAVX2;
-      kUpdateChroma = UpdateChromaAVX2;
+      kUpdateW = UpdateW_AVX2;
+      kUpdateChroma = UpdateChroma_AVX2;
     }
 #endif
   });

--- a/src/yuv_convert_avx2.cc
+++ b/src/yuv_convert_avx2.cc
@@ -1,0 +1,165 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Gather-based AVX2 variant of the Sharp RGB->YUV conversion's gamma-table
+// lookups compiled with -mavx2 only for this file.
+//
+// GammaToLinear()/LinearToGamma() are per-lane lookups at data-dependent
+// indices => fit the use of 'gather'.
+//
+// Author: Skal (pascal.massimino@gmail.com)
+
+#define SJPEG_NEED_ASM_HEADERS
+#include "sjpegi.h"
+
+#if defined(SJPEG_USE_AVX2) && defined(SJPEG_USE_AVX2_YUV_GATHER)
+
+namespace sjpeg {
+
+static const int kGammaToLinearBits = 14;  // must match GAMMA_TO_LINEAR_BITS
+
+// Filled by InitGammaTablesF()
+extern uint32_t kGammaToLinearTab[];
+extern uint32_t kLinearToGammaTab[];
+
+// C-version for left-over tails.
+extern uint32_t GammaToLinear(int v);
+extern uint32_t LinearToGamma(uint32_t value);
+extern uint32_t RGBToGray(uint32_t r, uint32_t g, uint32_t b);
+extern uint32_t ScaleDown(int a, int b, int c, int d);
+
+//------------------------------------------------------------------------------
+
+static inline __m256i GammaToLinear8(__m256i idx) {
+  return _mm256_i32gather_epi32(
+      reinterpret_cast<const int*>(kGammaToLinearTab), idx, 4);
+}
+
+// 'value' is in kGammaToLinearBits fractional precision.
+static inline __m256i LinearToGamma8(__m256i value) {
+  const __m256i v = _mm256_slli_epi32(value, 5);
+  const __m256i tab_pos = _mm256_srli_epi32(v, kGammaToLinearBits);
+  const __m256i x =
+      _mm256_and_si256(v, _mm256_set1_epi32((1 << kGammaToLinearBits) - 1));
+  const __m256i v0 = _mm256_i32gather_epi32(
+      reinterpret_cast<const int*>(kLinearToGammaTab), tab_pos, 4);
+  const __m256i v1 = _mm256_i32gather_epi32(
+      reinterpret_cast<const int*>(kLinearToGammaTab),
+      _mm256_add_epi32(tab_pos, _mm256_set1_epi32(1)), 4);
+  const __m256i v2 = _mm256_mullo_epi32(_mm256_sub_epi32(v1, v0), x);
+  return _mm256_add_epi32(v0, _mm256_srli_epi32(v2, kGammaToLinearBits));
+}
+
+static inline __m256i RGBToGray8(__m256i r, __m256i g, __m256i b) {
+  const __m256i round = _mm256_set1_epi32(1 << 16 >> 1);
+  const __m256i rr = _mm256_mullo_epi32(r, _mm256_set1_epi32(13933));
+  const __m256i gg = _mm256_mullo_epi32(g, _mm256_set1_epi32(46871));
+  const __m256i bb = _mm256_mullo_epi32(b, _mm256_set1_epi32(4732));
+  const __m256i luma =
+      _mm256_add_epi32(round, _mm256_add_epi32(rr, _mm256_add_epi32(gg, bb)));
+  return _mm256_srli_epi32(luma, 16);
+}
+
+static inline __m256i Load8U16AsI32(const fixed_y_t* p) {
+  return _mm256_cvtepu16_epi32(
+      _mm_loadu_si128(reinterpret_cast<const __m128i*>(p)));
+}
+
+// Truncating narrow of 8x int32 lanes to 8x 16b, matching the plain C
+// `(fixed_y_t)v` / `(fixed_t)v` casts.
+static inline void Store8TruncTo16(void* p, __m256i v) {
+  const __m256i masked = _mm256_and_si256(v, _mm256_set1_epi32(0xffff));
+  const __m256i packed = _mm256_packus_epi32(masked, masked);
+  const __m256i fixed = _mm256_permute4x64_epi64(packed, 0xd8);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(p),
+                    _mm256_castsi256_si128(fixed));
+}
+
+//------------------------------------------------------------------------------
+
+void UpdateWAVX2(const fixed_y_t* src, fixed_y_t* dst, int w) {
+  int i = 0;
+  for (; i + 8 <= w; i += 8) {
+    const __m256i R = GammaToLinear8(Load8U16AsI32(src + 0 * w + i));
+    const __m256i G = GammaToLinear8(Load8U16AsI32(src + 1 * w + i));
+    const __m256i B = GammaToLinear8(Load8U16AsI32(src + 2 * w + i));
+    const __m256i Y = RGBToGray8(R, G, B);
+    Store8TruncTo16(dst + i, LinearToGamma8(Y));
+  }
+  for (; i < w; ++i) {
+    const uint32_t R = GammaToLinear(src[0 * w + i]);
+    const uint32_t G = GammaToLinear(src[1 * w + i]);
+    const uint32_t B = GammaToLinear(src[2 * w + i]);
+    const uint32_t Y = RGBToGray(R, G, B);
+    dst[i] = (fixed_y_t)LinearToGamma(Y);
+  }
+}
+
+//------------------------------------------------------------------------------
+
+// Deinterleaves 8 pairs into 'a'/'b' lanes
+static inline void LoadPairs8(const fixed_y_t* p, __m256i* a, __m256i* b) {
+  const __m256i v = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p));
+  *a = _mm256_and_si256(v, _mm256_set1_epi32(0xffff));
+  *b = _mm256_srli_epi32(v, 16);
+}
+
+static inline __m256i ScaleDown8(__m256i a, __m256i b, __m256i c, __m256i d) {
+  const __m256i A = GammaToLinear8(a);
+  const __m256i B = GammaToLinear8(b);
+  const __m256i C = GammaToLinear8(c);
+  const __m256i D = GammaToLinear8(d);
+  __m256i sum = _mm256_add_epi32(_mm256_add_epi32(A, B), _mm256_add_epi32(C, D));
+  sum = _mm256_srli_epi32(_mm256_add_epi32(sum, _mm256_set1_epi32(2)), 2);
+  return LinearToGamma8(sum);
+}
+
+static inline __m256i ScaleDownChannel8(const fixed_y_t* src1,
+                                        const fixed_y_t* src2,
+                                        size_t channel_off) {
+  __m256i a1, b1, a2, b2;
+  LoadPairs8(src1 + channel_off, &a1, &b1);
+  LoadPairs8(src2 + channel_off, &a2, &b2);
+  return ScaleDown8(a1, b1, a2, b2);
+}
+
+void UpdateChromaAVX2(const fixed_y_t* src1, const fixed_y_t* src2,
+                      fixed_t* dst, size_t uv_w) {
+  size_t i = 0;
+  for (; i + 8 <= uv_w; i += 8, dst += 8, src1 += 16, src2 += 16) {
+    const __m256i r = ScaleDownChannel8(src1, src2, 0 * uv_w);
+    const __m256i g = ScaleDownChannel8(src1, src2, 2 * uv_w);
+    const __m256i b = ScaleDownChannel8(src1, src2, 4 * uv_w);
+    const __m256i W = RGBToGray8(r, g, b);
+    Store8TruncTo16(dst + 0 * uv_w, _mm256_sub_epi32(r, W));
+    Store8TruncTo16(dst + 1 * uv_w, _mm256_sub_epi32(g, W));
+    Store8TruncTo16(dst + 2 * uv_w, _mm256_sub_epi32(b, W));
+  }
+  for (; i < uv_w; ++i, ++dst, src1 += 2, src2 += 2) {
+    const uint32_t r = ScaleDown(src1[0 * uv_w + 0], src1[0 * uv_w + 1],
+                                 src2[0 * uv_w + 0], src2[0 * uv_w + 1]);
+    const uint32_t g = ScaleDown(src1[2 * uv_w + 0], src1[2 * uv_w + 1],
+                                 src2[2 * uv_w + 0], src2[2 * uv_w + 1]);
+    const uint32_t b = ScaleDown(src1[4 * uv_w + 0], src1[4 * uv_w + 1],
+                                 src2[4 * uv_w + 0], src2[4 * uv_w + 1]);
+    const int W = RGBToGray(r, g, b);
+    dst[0 * uv_w] = (fixed_t)(r - W);
+    dst[1 * uv_w] = (fixed_t)(g - W);
+    dst[2 * uv_w] = (fixed_t)(b - W);
+  }
+}
+
+}  // namespace sjpeg
+
+#endif  // SJPEG_USE_AVX2 && SJPEG_USE_AVX2_YUV_GATHER

--- a/src/yuv_convert_avx2.cc
+++ b/src/yuv_convert_avx2.cc
@@ -62,7 +62,7 @@ static inline __m256i LinearToGamma8(__m256i value) {
 }
 
 static inline __m256i RGBToGray8(__m256i r, __m256i g, __m256i b) {
-  const __m256i round = _mm256_set1_epi32(1 << 16 >> 1);
+  const __m256i round = _mm256_set1_epi32(1 << 15);
   const __m256i rr = _mm256_mullo_epi32(r, _mm256_set1_epi32(13933));
   const __m256i gg = _mm256_mullo_epi32(g, _mm256_set1_epi32(46871));
   const __m256i bb = _mm256_mullo_epi32(b, _mm256_set1_epi32(4732));
@@ -88,7 +88,7 @@ static inline void Store8TruncTo16(void* p, __m256i v) {
 
 //------------------------------------------------------------------------------
 
-void UpdateWAVX2(const fixed_y_t* src, fixed_y_t* dst, int w) {
+void UpdateW_AVX2(const fixed_y_t* src, fixed_y_t* dst, int w) {
   int i = 0;
   for (; i + 8 <= w; i += 8) {
     const __m256i R = GammaToLinear8(Load8U16AsI32(src + 0 * w + i));
@@ -134,8 +134,8 @@ static inline __m256i ScaleDownChannel8(const fixed_y_t* src1,
   return ScaleDown8(a1, b1, a2, b2);
 }
 
-void UpdateChromaAVX2(const fixed_y_t* src1, const fixed_y_t* src2,
-                      fixed_t* dst, size_t uv_w) {
+void UpdateChroma_AVX2(const fixed_y_t* src1, const fixed_y_t* src2,
+                        fixed_t* dst, size_t uv_w) {
   size_t i = 0;
   for (; i + 8 <= uv_w; i += 8, dst += 8, src1 += 16, src2 += 16) {
     const __m256i r = ScaleDownChannel8(src1, src2, 0 * uv_w);


### PR DESCRIPTION
* UpdateW/UpdateChroma AVX2 version uses vgather for the GammaToLinear/LinearToGamma lookups
* Bit-exact same as the C reference
* ~1.13x faster on ApplySharpYUVConversion alone
* ~1.09x end-to-end with default SjpegCompress params
   (SJPEG_YUV_AUTO only routes some images through SharpYUV)
* new gates: SJPEG_HAVE_AVX2 + SJPEG_USE_AVX2_YUV_GATHER (on by default)
* dynamic runtime dispatch with SupportsAVX2().