### PR TITLE
enc.cc,msvc: add clang_rt.builtins for __builtin_cpu_*

### DIFF
--- a/src/enc.cc
+++ b/src/enc.cc
@@ -203,6 +203,13 @@ bool SupportsNEON() {
 bool SupportsAVX2() {
   if (ForceSlowCImplementation) return false;
 #if defined(SJPEG_HAVE_AVX2) && (defined(__i386__) || defined(__x86_64__))
+#if defined(__clang__) && defined(_MSC_VER)
+#if defined(__x86_64__)
+#pragma comment(lib, "clang_rt.builtins-x86_64.lib")
+#else
+#pragma comment(lib, "clang_rt.builtins-i386.lib")
+#endif
+#endif
   __builtin_cpu_init();
   return __builtin_cpu_supports("avx2") != 0;
 #else


### PR DESCRIPTION
Fixes link errors related to `__builtin_cpu_init` and
`__builtin_cpu_supports` when using `clang-cl.exe` or `clang.exe` to
target the Windows ABI.

Issue #163
