### PR TITLE
enc: add restart marker support (DRI / RST0-RST7)

### DIFF
--- a/examples/sjpeg.cc
+++ b/examples/sjpeg.cc
@@ -143,6 +143,7 @@ int main(int argc, char * argv[]) {
     "  -qmin <float> ...... minimum acceptable quality factor during search\n"
     "  -qmax <float> ...... maximum acceptable quality factor during search\n"
     "  -tolerance <float> . tolerance for convergence during search\n"
+    "  -restart <int> ..... restart interval in MCU rows (default: 0 = off)\n"
     "\n"
     "  -gray .............. shortcut for '-yuv_mode 4'\n"
     "  -444 ............... shortcut for '-yuv_mode 3'\n"
@@ -232,6 +233,8 @@ int main(int argc, char * argv[]) {
       param.target_value = atof(argv[++c]);
     } else if (!strcmp(argv[c], "-pass") && c + 1 < argc) {
       param.passes = atoi(argv[++c]);
+    } else if (!strcmp(argv[c], "-restart") && c + 1 < argc) {
+      param.restart_interval_rows = atoi(argv[++c]);
     } else if (!strcmp(argv[c], "-no_metadata")) {
       no_metadata = true;
     } else if (!strcmp(argv[c], "-yuv_mode") && c + 1 < argc) {

--- a/man/sjpeg.1
+++ b/man/sjpeg.1
@@ -176,6 +176,15 @@ optimized for rate-distortion).
 .TP
 .B \-no_optim
 Disable Huffman code optimization (faster processing, larger file).
+.TP
+.BI \-restart " int
+Emit JPEG restart markers (\fBRST0\fP..\fBRST7\fP) every \fIint\fP rows of
+MCUs, along with the corresponding \fBDRI\fP header. Restart markers reset
+the entropy coder at regular intervals, which limits the damage a corrupted
+bitstream can do and allows a decoder to process intervals independently, at
+the cost of a slightly larger file. The default is \fB0\fP, which disables
+them. Note the interval is expressed in MCU \fIrows\fP, as with cjpeg's
+option of the same name.
 
 .SH BUGS
 Please report any bugs to the SJPEG discussion list:

--- a/src/api.cc
+++ b/src/api.cc
@@ -100,6 +100,7 @@ void EncoderParam::Init(float quality_factor) {
   tolerance = 1.;
   qmin = 0.;
   qmax = 100.;
+  restart_interval_rows = 0;
 }
 
 void EncoderParam::SetQuality(float quality_factor) {
@@ -177,6 +178,8 @@ bool Encoder::InitFromParam(const EncoderParam& param) {
                                                   : param.search_hook;
     if (!search_hook_->Setup(param)) return false;
   }
+
+  restart_interval_rows_ = param.restart_interval_rows;
 
   assert(memory_hook_ == (param.memory == nullptr ? GetDefaultMemoryManager()
                                                   : param.memory));

--- a/src/dichotomy.cc
+++ b/src/dichotomy.cc
@@ -93,6 +93,11 @@ void Encoder::StoreRunLevels(DCTCoeffs* coeffs) {
   ResetDCs();
   nb_run_levels_ = 0;
   int16_t* in = in_blocks_;
+  // Restart markers reset the decoder's DC predictors, so the dc_code_ deltas
+  // stored here must be relative to the very same boundaries that
+  // FinalPassScan() will later emit the markers at.
+  const int mcus_per_interval =
+      (restart_interval_rows_ > 0) ? restart_interval_rows_ * mb_w_ : 0;
   for (int n = 0; n < mb_w_ * mb_h_; ++n) {
     if (!CheckBuffers()) return;
     for (int c = 0; c < nb_comps_; ++c) {
@@ -106,6 +111,9 @@ void Encoder::StoreRunLevels(DCTCoeffs* coeffs) {
         ++coeffs;
         in += 64;
       }
+    }
+    if (mcus_per_interval > 0 && (n + 1) % mcus_per_interval == 0) {
+      ResetDCs();
     }
   }
 }
@@ -196,6 +204,7 @@ void Encoder::LoopScan() {
     if (ok_) {
       WriteDQT();
       WriteSOF();
+      WriteDRI();
       WriteDHT();
       WriteSOS();
       FinalPassScan(nb_mbs, base_coeffs);
@@ -230,6 +239,7 @@ size_t Encoder::HeaderSize() const {
   size += 8 + 3 * nb_comps_ + 2;  // SOF
   size += 6 + 2 * nb_comps_ + 2;  // SOS
   size += 2;                      // EOI
+  if (restart_interval_rows_ > 0) size += 6;  // DRI
   // DHT:
   for (int c = 0; c < (nb_comps_ == 1 ? 1 : 2); ++c) {   // luma, chroma
     for (int type = 0; type <= 1; ++type) {               // dc, ac
@@ -293,6 +303,13 @@ float Encoder::ComputeSize(const DCTCoeffs* coeffs) {
     BitCounter bc;
     BlocksSize(mb_w_ * mb_h_ * mcu_blocks_, coeffs, all_run_levels_, &bc);
     size += bc.Size();
+  }
+  if (restart_interval_rows_ > 0) {
+    // Each restart costs a 2-byte RSTn marker, plus the '1'-bits padding the
+    // preceding entropy data to a byte boundary (0..7 bits, ~4 on average).
+    const int nb_restarts =
+        (mb_h_ + restart_interval_rows_ - 1) / restart_interval_rows_ - 1;
+    size += nb_restarts * (2 * 8 + 4);
   }
   return size / 8.f;
 }

--- a/src/enc.cc
+++ b/src/enc.cc
@@ -328,6 +328,21 @@ void Encoder::CollectCoeffs() {
 ////////////////////////////////////////////////////////////////////////////////
 // 1-pass Scan
 
+void Encoder::EmitRestartMarker(int interval_idx) {
+  // No Reserve() is needed here: every caller runs inside a scan loop that has
+  // just called CheckBuffers(), which reserves more room than the largest
+  // possible MCU can consume, leaving ample slack for these 2 bytes.
+  bw_.Flush();
+  const uint8_t rst_marker[2] = {
+      0xff, static_cast<uint8_t>(0xd0 + (interval_idx & 7))};
+  bw_.PutBytes(rst_marker, 2);
+  // Required by SinglePassScan(), which codes DC differentially off DCs_[].
+  // On the FinalPassScan() path the DC codes are already baked into
+  // DCTCoeffs::dc_code_ (see StoreRunLevels(), which performs its own reset),
+  // so this is a no-op there.
+  ResetDCs();
+}
+
 void Encoder::SinglePassScan() {
   ResetDCs();
 
@@ -350,6 +365,12 @@ void Encoder::SinglePassScan() {
         }
       }
     }
+    // Skip the marker after the very last MCU row: a scan must not end on a
+    // restart marker.
+    if (restart_interval_rows_ > 0 &&
+        (mb_y + 1) % restart_interval_rows_ == 0 && mb_y + 1 < mb_h_) {
+      EmitRestartMarker((mb_y + 1) / restart_interval_rows_ - 1);
+    }
   }
 }
 
@@ -358,10 +379,19 @@ void Encoder::FinalPassScan(size_t nb_mbs, const DCTCoeffs* coeffs) {
   if (!CheckBuffers()) return;  // call needed to finalize all_run_levels_
   assert(reuse_run_levels_);
   const RunLevel* run_levels = all_run_levels_;
+  const size_t blocks_per_interval =
+      (restart_interval_rows_ > 0)
+          ? static_cast<size_t>(restart_interval_rows_) * mb_w_ * mcu_blocks_
+          : 0;
+  int interval_idx = 0;
   for (size_t n = 0; n < nb_mbs; ++n) {
     if (!CheckBuffers()) return;
     CodeBlock(&coeffs[n], run_levels);
     run_levels += coeffs[n].nb_coeffs_;
+    if (restart_interval_rows_ > 0 && (n + 1) % blocks_per_interval == 0 &&
+        n + 1 < nb_mbs) {
+      EmitRestartMarker(interval_idx++);
+    }
   }
 }
 
@@ -408,6 +438,10 @@ void Encoder::SinglePassScanOptimized() {
         }
       }
     }
+    if (restart_interval_rows_ > 0 &&
+        (mb_y + 1) % restart_interval_rows_ == 0) {
+      ResetDCs();
+    }
   }
 
   CompileEntropyStats();
@@ -451,6 +485,15 @@ bool Encoder::Encode() {
   mb_h_ = (H_ + (block_h_ - 1)) / block_h_;
   mb_x_max_ = W_ / block_w_;
   mb_y_max_ = H_ / block_h_;
+  // DRI stores the interval as a 16-bit count of MCUs, so a row-based interval
+  // can't exceed 0xffff MCUs. Clamp to the coarsest whole number of MCU rows
+  // that fits: restarts become more frequent than asked for, never less, and
+  // stay row-aligned as the scan loops and the DC resets require. Dimensions
+  // are capped at kMaxDimension, so mb_w_ <= 8192 and this is always >= 7.
+  if (restart_interval_rows_ > 0) {
+    const int max_rows = 0xffff / mb_w_;
+    if (restart_interval_rows_ > max_rows) restart_interval_rows_ = max_rows;
+  }
   const size_t nb_blocks = use_extra_memory_ ? mb_w_ * mb_h_ : 1;
   if (!AllocateBlocks(nb_blocks * mcu_blocks_)) return false;
 
@@ -496,6 +539,7 @@ void Encoder::SinglePassEncode() {
 
   // baseline coding
   WriteSOF();
+  WriteDRI();
 
   if (optimize_size_) {
     SinglePassScanOptimized();

--- a/src/headers.cc
+++ b/src/headers.cc
@@ -228,6 +228,22 @@ void Encoder::WriteDHT() {
   }
 }
 
+// DRI's interval field counts MCUs, whereas restart_interval_rows_ counts MCU
+// rows. Encode() has already clamped the latter so the product fits 16 bits.
+void Encoder::WriteDRI() {
+  if (restart_interval_rows_ <= 0) return;
+  const int interval = restart_interval_rows_ * mb_w_;
+  const uint8_t kDRIHeader[] = {0xff,
+                                0xdd,
+                                0x00,
+                                0x04,
+                                static_cast<uint8_t>(interval >> 8),
+                                static_cast<uint8_t>(interval & 0xff)};
+  ok_ = ok_ && bw_.Reserve(sizeof(kDRIHeader));
+  if (!ok_) return;
+  bw_.PutBytes(kDRIHeader, sizeof(kDRIHeader));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void Encoder::WriteSOS() {   // SOS

--- a/src/sjpeg.h
+++ b/src/sjpeg.h
@@ -216,6 +216,12 @@ struct EncoderParam {
   bool adaptive_bias;           // if true, use perceptual bias adaptation
   bool use_trellis;             // if true, use trellis-based optimization
 
+  // Emit restart markers (RST0-RST7) every 'restart_interval_rows' MCU rows.
+  // Any value <= 0 (the default) disables them. Note the unit is MCU *rows*:
+  // libjpeg's cinfo.restart_interval counts MCUs instead (its row-based
+  // equivalent is spelled cinfo.restart_in_rows).
+  int restart_interval_rows;
+
   // target size or distortion
   typedef enum {
     TARGET_NONE = 0,

--- a/src/sjpegi.h
+++ b/src/sjpegi.h
@@ -377,6 +377,7 @@ struct Encoder {
   void WriteDQT();
   void WriteSOF(bool progressive = false);
   void WriteDHT();
+  void WriteDRI();
   void WriteSOS();
   void WriteEOI();
 
@@ -416,6 +417,7 @@ struct Encoder {
 #endif  // !SJPEG_NO_PROGRESSIVE
 
   void ResetDCs();
+  void EmitRestartMarker(int interval_idx);
 
   // GetSamples() + fDCT_() for one MCU, into 'out'. Shared by the baseline
   // and progressive quantize loops.
@@ -551,6 +553,7 @@ struct Encoder {
   bool use_extra_memory_;     // save the unquantized coeffs (method 3, 4)
   bool reuse_run_levels_;     // save quantized run/levels   (method 1, 4, 5)
   bool use_trellis_;          // use trellis-quantization    (method 7, 8)
+  int restart_interval_rows_ = 0;  // MCU rows per restart interval (0 = off)
 
   int q_bias_;           // [0..255]: rounding bias for quant. of AC coeffs.
   Quantizer quants_[2];  // quant matrices

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -826,6 +826,222 @@ SJPEG_TEST(Progressive) {
 }
 #endif  // !SJPEG_NO_PROGRESSIVE
 
+SJPEG_TEST(RestartMarkers) {
+  const int kWidth = 64, kHeight = 64;
+  const std::vector<uint8_t> rgb = MakeRGB(kWidth, kHeight);
+
+  const uint8_t kMarkerByteDRI = 0xdd;   // define restart interval
+  const uint8_t kMarkerByteRST0 = 0xd0;  // first of the RST0..RST7 cycle
+
+  auto HasMarker = [](const std::string& jpeg, uint8_t marker_byte) {
+    const uint8_t* data = reinterpret_cast<const uint8_t*>(jpeg.data());
+    const size_t size = jpeg.size();
+    for (size_t i = 0; i + 1 < size; ++i) {
+      if (data[i] == 0xff && data[i + 1] == marker_byte) return true;
+    }
+    return false;
+  };
+
+  auto ExtractDRI = [](const std::string& jpeg) -> uint16_t {
+    const uint8_t* data = reinterpret_cast<const uint8_t*>(jpeg.data());
+    const size_t size = jpeg.size();
+    for (size_t i = 0; i + 5 < size; ++i) {
+      if (data[i] == 0xff && data[i + 1] == kMarkerByteDRI &&
+          data[i + 2] == 0x00 && data[i + 3] == 0x04) {
+        return (static_cast<uint16_t>(data[i + 4]) << 8) | data[i + 5];
+      }
+    }
+    return 0;
+  };
+
+  // Test 1: restart_interval_rows = 0 -> no DRI marker
+  {
+    sjpeg::EncoderParam param(85.0f);
+    param.restart_interval_rows = 0;
+    std::string out;
+    SJPEG_CHECK(EncodeRGB(rgb, kWidth, kHeight, param, &out));
+    SJPEG_CHECK(!HasMarker(out, kMarkerByteDRI));
+    SJPEG_CHECK(ExtractDRI(out) == 0);
+    SJPEG_CHECK(HasSize(out, kWidth, kHeight));
+  }
+
+  // Test 2: restart_interval_rows = 1 in YUV420 -> DRI = 4 MCUs per row, RST0
+  // present
+  {
+    sjpeg::EncoderParam param(85.0f);
+    param.restart_interval_rows = 1;
+    param.yuv_mode = SJPEG_YUV_420;
+    std::string out;
+    SJPEG_CHECK(EncodeRGB(rgb, kWidth, kHeight, param, &out));
+    SJPEG_CHECK(HasMarker(out, kMarkerByteDRI));
+    SJPEG_CHECK(ExtractDRI(out) == 4);
+    SJPEG_CHECK(HasMarker(out, kMarkerByteRST0));
+    SJPEG_CHECK(HasSize(out, kWidth, kHeight));
+  }
+
+  // Test 3: restart_interval_rows = 2 in YUV420 -> DRI = 8 MCUs
+  {
+    sjpeg::EncoderParam param(85.0f);
+    param.restart_interval_rows = 2;
+    param.yuv_mode = SJPEG_YUV_420;
+    std::string out;
+    SJPEG_CHECK(EncodeRGB(rgb, kWidth, kHeight, param, &out));
+    SJPEG_CHECK(HasMarker(out, kMarkerByteDRI));
+    SJPEG_CHECK(ExtractDRI(out) == 8);
+    SJPEG_CHECK(HasSize(out, kWidth, kHeight));
+  }
+
+  // Number of MCUs per row, which is what DRI counts: 16x16 MCUs in 4:2:0,
+  // 8x8 otherwise.
+  auto MCUsPerRow = [](int w, SjpegYUVMode yuv_mode) {
+    const int block_w = (yuv_mode == SJPEG_YUV_420) ? 16 : 8;
+    return (w + block_w - 1) / block_w;
+  };
+
+  // Test 4: Decodability across resolutions, intervals, YUV modes, and Huffman
+  // modes. DRI must hold the exact MCU count matching the requested rows.
+  const int dimensions[][2] = {{16, 16}, {64, 64}, {127, 93}, {320, 240}};
+  const int intervals[] = {0, 1, 2, 4};
+  const SjpegYUVMode yuv_modes[] = {SJPEG_YUV_420, SJPEG_YUV_444,
+                                    SJPEG_YUV_400};
+
+  for (size_t d = 0; d < ARRAY_SIZE(dimensions); ++d) {
+    const int w = dimensions[d][0];
+    const int h = dimensions[d][1];
+    const std::vector<uint8_t> test_rgb = MakeRGB(w, h);
+    for (size_t i = 0; i < ARRAY_SIZE(intervals); ++i) {
+      const int restart = intervals[i];
+      for (size_t y = 0; y < ARRAY_SIZE(yuv_modes); ++y) {
+        for (int opt = 0; opt <= 1; ++opt) {
+          sjpeg::EncoderParam param(80.0f);
+          param.yuv_mode = yuv_modes[y];
+          param.restart_interval_rows = restart;
+          param.Huffman_compress = (opt == 1);
+          std::string out;
+          SJPEG_CHECK(EncodeRGB(test_rgb, w, h, param, &out));
+          SJPEG_CHECK(HasSize(out, w, h));
+          if (restart > 0) {
+            SJPEG_CHECK(HasMarker(out, kMarkerByteDRI));
+            SJPEG_CHECK(ExtractDRI(out) == restart * MCUsPerRow(w, yuv_modes[y]));
+          } else {
+            SJPEG_CHECK(!HasMarker(out, kMarkerByteDRI));
+          }
+        }
+      }
+    }
+  }
+
+  // Test 5: the multi-pass target-size/PSNR search path writes its own
+  // headers and stores DC deltas ahead of the final scan, so it needs DRI
+  // and the interval DC resets wired up independently of the single-pass one.
+  {
+    const int w = 320, h = 240;
+    const std::vector<uint8_t> test_rgb = MakeRGB(w, h);
+    const struct {
+      sjpeg::EncoderParam::TargetMode mode;
+      float value;
+    } kTargets[] = {{sjpeg::EncoderParam::TARGET_SIZE, 8000.f},
+                    {sjpeg::EncoderParam::TARGET_PSNR, 38.f}};
+    for (size_t t = 0; t < ARRAY_SIZE(kTargets); ++t) {
+      for (size_t i = 0; i < ARRAY_SIZE(intervals); ++i) {
+        const int restart = intervals[i];
+        sjpeg::EncoderParam param(80.0f);
+        param.yuv_mode = SJPEG_YUV_420;
+        param.target_mode = kTargets[t].mode;
+        param.target_value = kTargets[t].value;
+        param.passes = 5;
+        param.restart_interval_rows = restart;
+        std::string out;
+        SJPEG_CHECK(EncodeRGB(test_rgb, w, h, param, &out));
+        SJPEG_CHECK(HasSize(out, w, h));
+        SJPEG_CHECK(HasMarker(out, kMarkerByteDRI) == (restart > 0));
+        if (restart > 0) {
+          SJPEG_CHECK(ExtractDRI(out) == restart * MCUsPerRow(w, SJPEG_YUV_420));
+        }
+      }
+    }
+  }
+
+  // Test 6: DRI's interval field is 16 bits, so a row-based interval that
+  // would exceed 0xffff MCUs is clamped down to whole rows. It must never
+  // wrap (which silently desynchronizes the decoder) nor reach zero (which
+  // means 'no restarts' while markers are still being emitted). The image is
+  // sized so that the clamped interval is still shorter than the picture,
+  // hence markers really are emitted and the clamp has to reach the scan
+  // loops, not merely the header.
+  {
+    const int w = 2048, h = 2048;  // 4:0:0 -> 256 MCUs/row, 256 MCU rows
+    const int mcus_per_row = MCUsPerRow(w, SJPEG_YUV_400);
+    const int max_rows = 0xffff / mcus_per_row;  // 255, i.e. under 256 rows
+    const std::vector<uint8_t> test_rgb = MakeRGB(w, h);
+    const int requested[] = {max_rows - 1, max_rows, max_rows + 1,
+                             4 * max_rows};
+    for (size_t i = 0; i < ARRAY_SIZE(requested); ++i) {
+      sjpeg::EncoderParam param(80.0f);
+      param.yuv_mode = SJPEG_YUV_400;
+      param.restart_interval_rows = requested[i];
+      std::string out;
+      SJPEG_CHECK(EncodeRGB(test_rgb, w, h, param, &out));
+      SJPEG_CHECK(HasSize(out, w, h));
+      const int expected_rows =
+          (requested[i] < max_rows) ? requested[i] : max_rows;
+      const int dri = ExtractDRI(out);
+      SJPEG_CHECK(dri == expected_rows * mcus_per_row);
+      SJPEG_CHECK(dri > 0 && dri <= 0xffff);
+      // The clamped interval really does restart, so the clamp must have
+      // reached the scan loops and not just the header.
+      SJPEG_CHECK(HasMarker(out, kMarkerByteRST0));
+    }
+  }
+
+  // Test 7: trellis-based quantization (methods 7 and 8) substitutes its own
+  // quantizer but reaches the very same scan loops, through either
+  // SinglePassScan() or SinglePassScanOptimized()/FinalPassScan() depending on
+  // Huffman_compress. Restart markers must survive both.
+  {
+    const int w = 160, h = 120;
+    const std::vector<uint8_t> test_rgb = MakeRGB(w, h);
+    for (size_t i = 0; i < ARRAY_SIZE(intervals); ++i) {
+      const int restart = intervals[i];
+      for (int adapt = 0; adapt <= 1; ++adapt) {
+        for (int opt = 0; opt <= 1; ++opt) {
+          sjpeg::EncoderParam param(80.0f);
+          param.yuv_mode = SJPEG_YUV_420;
+          param.use_trellis = true;
+          param.adaptive_quantization = (adapt == 1);
+          param.Huffman_compress = (opt == 1);
+          param.restart_interval_rows = restart;
+          std::string out;
+          SJPEG_CHECK(EncodeRGB(test_rgb, w, h, param, &out));
+          SJPEG_CHECK(HasSize(out, w, h));
+          SJPEG_CHECK(HasMarker(out, kMarkerByteDRI) == (restart > 0));
+          if (restart > 0) {
+            SJPEG_CHECK(ExtractDRI(out) == restart * MCUsPerRow(w, SJPEG_YUV_420));
+          }
+        }
+      }
+    }
+  }
+
+  // Test 8: a negative interval is meaningless; every consumer guards on
+  // '> 0', so it must behave exactly like 'disabled'.
+  {
+    const int w = 64, h = 64;
+    const std::vector<uint8_t> test_rgb = MakeRGB(w, h);
+    const int negatives[] = {-1, -7, -1000};
+    for (size_t i = 0; i < ARRAY_SIZE(negatives); ++i) {
+      sjpeg::EncoderParam param(80.0f);
+      param.yuv_mode = SJPEG_YUV_420;
+      param.restart_interval_rows = negatives[i];
+      std::string out;
+      SJPEG_CHECK(EncodeRGB(test_rgb, w, h, param, &out));
+      SJPEG_CHECK(HasSize(out, w, h));
+      SJPEG_CHECK(!HasMarker(out, kMarkerByteDRI));
+      SJPEG_CHECK(ExtractDRI(out) == 0);
+    }
+  }
+}
+
 }  // namespace
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
EncoderParam::restart_interval_rows makes the encoder emit a DRI header and RSTn markers every N rows of MCUs, resetting the DC predictors at each interval boundary. Restart markers bound the damage a corrupted bitstream can cause and let a decoder work on intervals independently, in exchange for a couple of bytes per interval. They are off by default, so existing output is unchanged.

The interval is expressed in MCU rows rather than MCUs, matching cjpeg's -restart: sjpeg's scan loops and DC resets are row-based, and a row-aligned interval is the only kind that all of them can agree on. DRI's Ri field is 16 bits, so the row count is clamped to the coarsest whole number of rows whose MCU count still fits, following libjpeg's jcmaster.c -- restarts become more frequent than requested, never less.

Both the single-pass and the multi-pass (-size / -psnr) paths are covered. The latter writes its own headers and stores DC deltas ahead of the final scan, so it needs DRI emission and the interval DC resets wired up separately; its size estimator also accounts for the extra RSTn bytes and the padding bits that precede them, so convergence is not thrown off.

Adds a -restart option to the sjpeg tool and documents it in man/sjpeg.1, plus a unit test covering the interval-to-DRI arithmetic across resolutions, subsampling modes, Huffman and trellis quantization settings, the multi-pass search, and the 16-bit clamp.